### PR TITLE
refactors dossier builder to a more powerful and versatile dossierBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .prettierignore
+.idea

--- a/dt/AppBuilderService.js
+++ b/dt/AppBuilderService.js
@@ -284,7 +284,7 @@ function AppBuilderService(environment, opts) {
             if (err)
                 return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
             let commands = filesToCommands(files);
-            if (!commands || commands.length === 0){
+            if (commands.length === 0){
                 console.log(`Application ${slotPath} does not require patching`);
                 return callback(undefined, dsu);
             }

--- a/dt/AppBuilderService.js
+++ b/dt/AppBuilderService.js
@@ -1,0 +1,554 @@
+/**
+ * @module dt
+ */
+
+/**
+ *
+ */
+const FileService = require("./FileService");
+
+const DSU_SPECIFIC_FILES = ["dsu-metadata.log", "manifest"]
+const {_getResolver, _getKeySSISpace} = require('./commands/utils');
+
+/**
+ * Default Options set for the {@link AppBuilderService}
+ * <pre>
+ *     {
+            anchoring: "default",
+            publicSecretsKey: '-$Identity-',
+            environmentKey: "-$Environment-",
+            basePath: "",
+            stripBasePathOnInstall: false,
+            walletPath: "",
+            hosts: "",
+            hint: undefined,
+            vault: "vault",
+            seedFileName: "seed",
+            appsFolderName: "apps",
+            appFolderName: "app",
+            codeFolderName: "code",
+            initFile: "init.file",
+            environment: {},
+            slots:{
+                primary: "wallet-patch",
+                secondary: "apps-patch"
+            }
+        }
+ * </pre>
+ */
+const OPTIONS = {
+    anchoring: "default",
+    publicSecretsKey: '-$Identity-',
+    environmentKey: "-$Environment-",
+    basePath: "",
+    stripBasePathOnInstall: false,
+    walletPath: "",
+    hosts: "",
+    hint: undefined,
+    vault: "vault",
+    seedFileName: "seed",
+    appsFolderName: "apps",
+    appFolderName: "app",
+    codeFolderName: "code",
+    initFile: "init.file",
+    environment: {},
+    slots:{
+        primary: "wallet-patch",
+        secondary: "apps-patch"
+    }
+}
+
+/**
+ * Convert the Environment object into the Options object
+ */
+const envToOptions = function(env, opts){
+    let options = Object.assign({}, OPTIONS, opts);
+    options.environment = env;
+    options.vault = env.vault;
+    options.anchoring = env.domain;
+    options.basePath = env.basePath;
+    options.walletPath = env.basePath.split('/').reduce((sum, s) => sum === '' && s !== '/' ? s : sum, '');
+    const opendsu = require('opendsu');
+    options.hosts = $$.environmentType === 'browser'
+        ? `${opendsu.loadApi('system').getEnvironmentVariable(opendsu.constants.BDNS_ROOT_HOSTS)}`
+        : `localhost:8080`;
+    return options;
+}
+
+/**
+ *
+ * @param {object} environment typically comes from an environment.js file is the ssapps. Overrides some options
+ * @param {object} [opts] options object mimicking {@link OPTIONS}
+ */
+function AppBuilderService(environment, opts) {
+    const options = envToOptions(environment, opts);
+    const dossierBuilder = new (require("./DossierBuilder"))();
+
+    const fileService = new FileService(options);
+
+    /**
+     * Lists a DSUs content
+     * @param {KeySSI} keySSI
+     * @param {function(err, files, mounts)} callback
+     * @private
+     */
+    const getDSUContent = function (keySSI, callback) {
+        _getResolver().loadDSU(keySSI, (err, dsu) => {
+            if (err)
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not load DSU with SSI ${keySSI}`, err));
+            dsu.listFiles("/", {ignoreMounts: true}, (err, files) => {
+                if (err)
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not retrieve DSU content`, err));
+                dsu.listMountedDSUs("/", (err, mounts) => {
+                    if (err)
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not retrieve DSU mounts`, err));
+                    callback(undefined, files.filter(f => {
+                        return DSU_SPECIFIC_FILES.indexOf(f) === -1;
+                    }), mounts, dsu);
+                });
+            });
+        });
+    }
+
+    /**
+     * Creates an Arrays SSI off a secret list
+     *
+     * Adds options.hint to hit if available
+     * @param {string[]} secrets
+     * @param {function(err, ArraySSI)} callback
+     * @private
+     */
+    const createArraySSI = function(secrets, callback){
+        const key = _getKeySSISpace().createArraySSI(options.anchoring, secrets, 'v0', options.hint ? JSON.stringify(options.hint) : undefined);
+        callback(undefined, key);
+    }
+
+    /**
+     * Creates a Wallet SSI off a secret list
+     *
+     * Adds options.hint to hit if available
+     * @param {string[]} secrets
+     * @param {function(err, ArraySSI)} callback
+     */
+    const createWalletSSI = function(secrets, callback){
+        const key = _getKeySSISpace().createTemplateWalletSSI(options.anchoring, secrets, 'v0', options.hint ? JSON.stringify(options.hint) : undefined);
+        callback(undefined, key);
+    }
+
+    /**
+     * Creates an Arrays SSI off a secret list
+     *
+     * Adds options.hint to hit if available
+     * @param {string} specificString
+     * @param {function(err, TemplateSeedSSI)} callback
+     */
+    const createSSI = function(specificString, callback){
+        const key = _getKeySSISpace().createTemplateSeedSSI(options.anchoring, specificString, undefined, 'v0', options.hint ? JSON.stringify(options.hint) : undefined);
+        callback(undefined, key);
+    }
+
+    /**
+     * Creates a DSU of an ArraySSI
+     * @param {string[]} secrets
+     * @param {object} opts DSU Creation Options
+     * @param {function(err, Archive)} callback
+     */
+    const createWalletDSU = function(secrets, opts, callback){
+        createWalletSSI(secrets, (err, keySSI) => {
+            _getResolver().createDSUForExistingSSI(keySSI, opts, (err, dsu) => {
+                if (err)
+                    return callback(`Could not create const DSU ${err}`);
+                callback(undefined, dsu);
+            });
+        });
+    }
+
+    /**
+     * Creates a DSU of an ArraySSI
+     * @param {string} specific String for Seed SSI
+     * @param {object} opts DSU Creation Options
+     * @param {function(err, Archive)} callback
+     */
+    const createDSU = function(specific, opts, callback){
+        createSSI(specific, (err, keySSI) => {
+            _getResolver().createDSU(keySSI, opts, (err, dsu) => {
+                if (err)
+                    return callback(`Could not create const DSU ${err}`);
+                callback(undefined, dsu);
+            });
+        });
+    }
+
+    /**
+     * Creates a DSU of an ArraySSI
+     * @param {string[]} secrets
+     * @param {object} opts DSU Creation Options
+     * @param {function(err, Archive)} callback
+     */
+    const createConstDSU = function(secrets,opts , callback){
+        createArraySSI(secrets, (err, keySSI) => {
+            _getResolver().createDSUForExistingSSI(keySSI, opts, (err, dsu) => {
+                if (err)
+                    return callback(`Could not create const DSU ${err}`);
+                callback(undefined, dsu);
+            });
+        });
+    }
+
+    const getDSUFactory = function(isConst, isWallet){
+        return isConst ? (isWallet ? createWalletDSU : createConstDSU) : createDSU;
+    }
+
+    /**
+     * Creates a new DSU (Const or not) and clones the content another DSU into it
+     * @param {object|string} arg can be a secrets object or a string depending on if it's a const DSU or not. A secrets object is like:
+     * <pre>
+     *     {
+     *         secretName: {
+     *             secret: "...",
+     *             public: (defaults to false. If true will be made available to the created DSU for use of initialization Scripts)
+     *         },
+     *         (...)
+     *     }
+     * </pre>
+     * @param {KeySSI} keyForDSUToClone
+     * @param {boolean} [isConst] decides if the Created DSU is Const or not. defaults to true
+     * @param {function(err, KeySSI)} callback
+     */
+    this.clone = function (arg, keyForDSUToClone, isConst, callback) {
+        if (typeof isConst === 'function'){
+            callback = isConst;
+            isConst = true;
+        }
+        parseSecrets(true, arg, (err, keyGenArgs, publicSecrets) => {
+            if (err)
+                return callback(err);
+            getDSUContent(keyForDSUToClone, (err, files, mounts, dsuToClone) => {
+                if (err)
+                    return callback(err);
+                console.log(`Loaded Template DSU with key ${keyForDSUToClone}:\nmounts: ${mounts}`);
+                getDSUFactory(isConst)(keyGenArgs, (err, destinationDSU) => {
+                    if (err)
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
+                    doClone(dsuToClone, destinationDSU, files, mounts,  publicSecrets,(err, keySSI) => {
+                        if (err)
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
+                        console.log(`DSU ${keySSI} as a clone of ${keyForDSUToClone} was created`);
+                        // if (publicSecrets)
+                        //     return writeToCfg(destinationDSU, publicSecrets, err => callback(err, keySSI));
+                        callback(undefined, keySSI);
+                    });
+                });
+            });
+        });
+    }
+
+    const _getPatchContent = function(appName, callback){
+        fileService.getFolderContentAsJSON(appName, (err, content) => {
+           if (err)
+               return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not retrieve patch content for ${appName}`, err));
+           try {
+               content = JSON.parse(content);
+           } catch (e) {
+               return callback(`Could not parse content`);
+           }
+            content['/'][options.seedFileName] = undefined;
+            delete content['/'][options.seedFileName];
+
+           callback(undefined, content);
+        });
+    }
+
+    const filesToCommands = (content) => {
+        let commands = [];
+        for (let directory in content)
+            if (content.hasOwnProperty(directory)){
+                let directoryFiles = content[directory];
+                for (let fileName in directoryFiles)
+                    if (directoryFiles.hasOwnProperty(fileName))
+                        commands.push(`createfile ${directory}/${fileName} ${directoryFiles[fileName]}`);
+            }
+        return commands;
+    }
+
+    /**
+     * Copies the patch files from the path folder onto the DSU
+     * @param {Archive} dsu
+     * @param {string} slotPath should be '{@link OPTIONS.slots}[/appName]' when appName is required
+     * @param {function(err, Archive, KeySSI)} callback
+     */
+    const patch = function(dsu, slotPath, callback) {
+        // Copy any files found in the RESPECTIVE PATCH FOLDER on the local file system
+        // into the app's folder
+        _getPatchContent(slotPath, (err, files) => {
+            if (err)
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
+            let commands = filesToCommands(files);
+            if (!commands || commands.length === 0){
+                console.log(`Application ${slotPath} does not require patching`);
+                return callback(undefined, dsu);
+            }
+
+            dossierBuilder.buildDossier(dsu, commands, (err, keySSI) => {
+                if (err)
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
+                console.log(`Application ${slotPath} successfully patched`);
+                callback(undefined, dsu, keySSI);
+            });
+        });
+    }
+
+    /**
+     * When writing the env to an SSApp, because she'll run in an iFrame,
+     * its basePath will always be '/' unlike the loader, we have the option to strip the base path id that's desirable
+     * @param {object} env
+     */
+    const resetBasePath = function(env){
+        if (!env.stripBasePathOnInstall)
+            return env;
+        return Object.assign({}, env, {basePath: '/'});
+    }
+
+    /**
+     * Reads from {@link OPTIONS.initFile} and executes the commands founds there via {@link DossierBuilder#buildDossier}
+     * @param {Archive} instance
+     * @param {object} publicSecrets what elements of the registration elements should be passed onto the SSApp
+     * @param {function(err, Archive)} callback
+     */
+    const initializeInstance = function(instance, publicSecrets, callback){
+        instance.readFile(`${options.codeFolderName}/${options.initFile}`, (err, data) => {
+            if (err) {
+                console.log(`No init file found. Initialization complete`);
+                return callback(undefined, instance);
+            }
+
+            // embed the environment and identity into in the initializations commands
+            let commands = data.toString().replace(options.environmentKey, JSON.stringify(resetBasePath(options.environment)));
+            commands = (publicSecrets
+                    ? commands.replace(options.publicSecretsKey, JSON.stringify(publicSecrets))
+                    : commands)
+                .split(/\r?\n/).map(cmd => cmd.trim()).filter(cmd => !!cmd && !cmd.startsWith('##'));
+
+            dossierBuilder.buildDossier(instance, commands, (err, keySSI) => {
+                if (err)
+                   return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not initialize SSApp instance`, err));
+                console.log(`Instance successfully initialized: ${keySSI}`);
+                callback(undefined, instance);
+            });
+        });
+    }
+
+    /**
+     * Parser the secrets object according to if its a wallet or not
+     * @param {boolean} isWallet
+     * @param {object|string} secrets can be a secrets object or a string depending on if it's a wallet or not. A secrets object is like:
+     * <pre>
+     *     {
+     *         secretName: {
+     *             secret: "...",
+     *             public: (defaults to false. If true will be made available to the created DSU for use of initialization Scripts)
+     *         },
+     *         (...)
+     *     }
+     * </pre>
+     * @param {function(err, string|string[], publicSecrets)} callback
+     */
+    const parseSecrets = function(isWallet, secrets, callback){
+        let specificArg = secrets;
+        let publicSecrets = undefined;
+        if (isWallet && typeof secrets === 'object'){
+            specificArg = [];
+            publicSecrets = {};
+            Object.entries(secrets).forEach(e => {
+                if (e[1].public)
+                    publicSecrets[e[0]] = e[1].secret;
+                specificArg.push(e[1].secret);
+            });
+        }
+        callback(undefined, specificArg, publicSecrets);
+    }
+
+    this.parseSecrets = parseSecrets;
+
+    /**
+     * Builds an SSApp
+     * @param {boolean} isWallet
+     * @param {object|string} secrets according to {@link parseSecrets}
+     * @param {string} seed
+     * @param {string} [name]
+     * @param {function(err, KeySSI, Archive)} callback
+     */
+    const buildApp = function(isWallet, secrets, seed, name, callback){
+        if (typeof name === 'function'){
+            if (!isWallet)
+                return callback(`No SSApp name provided`);
+            callback = name;
+            name = undefined;
+        }
+
+        const patchAndInitialize = function(instance, publicSecrets, callback){
+            const patchPath = isWallet ? `${options.slots.primary}` : `${options.slots.secondary}/${name}`;
+            patch(instance, patchPath, (err) => {
+                if (err)
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Error patching SSApp ${name}`, err));
+                initializeInstance(instance, publicSecrets, (err) => {
+                    if (err)
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
+                    instance.getKeySSIAsString((err, keySSI) => {
+                        if (err)
+                            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
+                        callback(undefined, keySSI);
+                    });
+                });
+            });
+        }
+
+        parseSecrets(isWallet, secrets, (err, keyArgs, publicSecrets) => {
+            if (err)
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
+            getDSUFactory(isWallet, isWallet)(keyArgs, isWallet ? {dsuTypeSSI: seed} : undefined, (err, wallet) => {
+                if (err)
+                    return callback(`Could not create instance`);
+
+                const instance = isWallet ? wallet.getWritableDSU() : wallet;
+
+                if (isWallet)
+                    return patchAndInitialize(instance, publicSecrets, (err, key) => callback(err, key, wallet));
+
+                instance.mount(`${options.codeFolderName}`, seed, (err) => {
+                    if (err)
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not mount Application code in instance`, err));
+                    patchAndInitialize(instance, publicSecrets, (err, key) => callback(err, key, wallet));
+                });
+            });
+        });
+    }
+
+    /**
+     * Retrieves the list of Applications to be installed
+     * @param {function(err, object)} callback
+     */
+    const getListOfAppsForInstallation = (callback) => {
+        fileService.getFolderContentAsJSON(options.slots.secondary, function (err, data) {
+            if (err){
+                console.log(`No Apps found`)
+                return callback(undefined, {});
+            }
+
+            let apps;
+
+            try {
+                apps = JSON.parse(data);
+            } catch (e) {
+                return callback(`Could not parse App list`);
+            }
+
+            callback(undefined, apps);
+        });
+    };
+
+    /**
+     * Installs all aps in the apps folder in the wallet
+     * @param {Archive} wallet
+     * @param {function(err, object)} callback returns the apps details
+     */
+    const installApps = function(wallet, callback){
+        const performInstallation = function(wallet, apps, appList, callback){
+            if (!appList.length)
+                return callback();
+            let appName = appList.pop();
+            const appInfo = apps[appName];
+
+            if (appName[0] === '/')
+                appName = appName.replace('/', '');
+
+            const mountApp = (newAppSeed) => {
+                wallet.mount(`/${options.appsFolderName}/${appName}`, newAppSeed, (err) => {
+                    if (err)
+                        return callback("Failed to mount in folder" + `/apps/${appName}: ${err}`);
+
+                    performInstallation(wallet, apps, appList, callback);
+                });
+            };
+
+            // If new instance is not demanded just mount (leftover code from privatesky.. when is it not a new instance?)
+            if (appInfo.newInstance === false)
+                return mountApp(appInfo.seed);
+
+            buildApp(false, undefined, appInfo.seed, appName, (err, keySSI) => {
+                if (err)
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to build app ${appName}`, err));
+                mountApp(keySSI);
+            });
+        }
+
+        getListOfAppsForInstallation((err, apps) => {
+            if (err)
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper( err));
+            apps = apps || {};
+            let appList = Object.keys(apps).filter(n => n !== '/');
+            if(!appList.length)
+                return callback(undefined, appList);
+            let tempList = [...appList]
+            performInstallation(wallet, apps, tempList, (err) => {
+                if (err)
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not complete installations`, err));
+                callback(undefined, appList);
+            });
+        });
+    }
+
+    /**
+     * Builds a new SSApp from the provided secrets
+     * @param {KeySSI} seed the SSApp's keySSI
+     * @param {string} name the SSApp's name
+     * @param {function(err, KeySSI, Archive)} callback
+     */
+    this.buildSSApp = function(seed, name, callback){
+        return buildApp(false, seed, name, callback);
+    }
+
+    /**
+     * Builds a new Wallet from the provided secrets
+     * @param {object|string} secrets according to {@link parseSecrets}
+     * @param {function(err, KeySSI, Archive)} callback
+     */
+    this.buildWallet = function(secrets, callback){
+        fileService.getWalletSeed((err, seed) => {
+            if (err)
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Could not retrieve template wallet SSI.", err));
+            buildApp(true, secrets, seed, (err, keySSI, wallet) => {
+                if (err)
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not build wallet`, err));
+                console.log(`Wallet built with SSI ${keySSI}`);
+                installApps(wallet, (err, appList) => {
+                    if (err)
+                        return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not Install Applications ${JSON.stringify(appList)}`, err));
+                    if (appList.length)
+                        console.log(`Applications installed successfully`);
+                    callback(undefined, keySSI, wallet);
+                })
+            });
+        });
+    }
+
+    this.loadWallet = function(secrets, callback){
+        parseSecrets(true, secrets, (err, keyGenArgs, publicSecrets) => {
+            if (err)
+                return callback(err);
+            createWalletSSI(keyGenArgs, (err, keySSI) => {
+                if (err)
+                    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Could not create wallet with ssi ${{keySSI}}`, err));
+                console.log(`Loading wallet with ssi ${keySSI.getIdentifier()}`);
+                _getResolver().loadDSU(keySSI, (err, wallet) => {
+                    if (err)
+                        return callback(`Could not load wallet DSU ${err}`);
+                    wallet = wallet.getWritableDSU();
+                    console.log(`wallet Loaded`);
+                    wallet.getKeySSIAsString(callback);
+                });
+            });
+        });
+    }
+}
+module.exports = AppBuilderService;

--- a/dt/DossierBuilder.js
+++ b/dt/DossierBuilder.js
@@ -2,15 +2,7 @@
  * @module dt
  */
 
-/**
- * Enum of Accepted Key Types
- */
-const KEY_TYPE = {
-    CONST: "const",
-    SEED: "seed"
-}
-
-const {_getByName} = require('./commands');
+const {_getByName } = require('./commands');
 const {_getResolver, _getKeySSISpace} = require('./commands/utils');
 
 /**

--- a/dt/DossierBuilder.js
+++ b/dt/DossierBuilder.js
@@ -1,14 +1,17 @@
-const fs = require("fs");
-const openDSU = require("opendsu");
-const keyssi = openDSU.loadApi("keyssi");
-const resolver = openDSU.loadApi("resolver");
+/**
+ * @module dt
+ */
 
-const operations = {
-    DELETE: "delete",
-    ADD_FOLDER: "addfolder",
-    ADD_FILE: "addfile",
-    MOUNT: "mount"
+/**
+ * Enum of Accepted Key Types
+ */
+const KEY_TYPE = {
+    CONST: "const",
+    SEED: "seed"
 }
+
+const {_getByName} = require('./commands');
+const {_getResolver, _getKeySSISpace} = require('./commands/utils');
 
 /**
  * Automates the Dossier Building process
@@ -23,6 +26,7 @@ const operations = {
  *          "domain": "default",
  *     }
  * </pre>
+ *
  * For a Simple SSApp (with only mounting of cardinal/themes and creation of code folder) the commands would be like:
  * <pre>
  *     delete /
@@ -30,215 +34,157 @@ const operations = {
  *     mount ../cardinal/seed /cardinal
  *     mount ../themes/'*'/seed /themes/'*'
  * </pre>
+ * @param {Archive} [sourceDSU] if provided will perform all OPERATIONS from the sourceDSU as source and not the fs
+ * @param {VarStore} [varStore]
  */
-const DossierBuilder = function(){
+const DossierBuilder = function(sourceDSU, varStore){
 
-    /**
-     * recursively executes the provided func with the dossier and each of the provided arguments
-     * @param {DSU Archive} dossier: The DSU instance
-     * @param {function} func: function that accepts the dossier and one param as arguments
-     * @param {any} arguments: a list of arguments to be consumed by the func param
-     * @param {function} callback: callback function. The first argument must be err
-     */
-    let execute = function (dossier, func, arguments, callback) {
-        let arg = arguments.pop();
-        if (! arg)
-            return callback();
-        let options = typeof arg === 'object' && arg.options ? arg.options : undefined;
-        func(dossier, arg, options, (err, result) => {
-            if (err)
-                return callback(err);
-
-            if (arguments.length !== 0) {
-                execute(dossier, func, arguments, callback);
-            } else {
-                callback(undefined, result);
-            }
-        });
-    };
-
-    let del = function (bar, path, options, callback) {
-        if (typeof options === 'function'){
-            callback = options;
-            options = {}
-        }
-        options = options || {ignoreMounts: false};
-        console.log("Deleting " + path);
-        bar.delete(path, options, err => callback(err, bar));
-    };
-
-    let addFolder = function (folder_root = "/") {
-        return function (bar, arg, options, callback){
-            if (typeof options === 'function'){
-                callback = options;
-                options = {}
-            }
-            options = options || {batch: false, encrypt: false};
-            console.log("Adding Folder " + folder_root + arg)
-            bar.addFolder(arg, folder_root, options, err => callback(err, bar));
-        };
-    };
-
-    let addFile = function (bar, arg, options, callback) {
-        if (typeof options === 'function'){
-            callback = options;
-            options = {}
-        }
-        options = options || {encrypt: true, ignoreMounts: false}
-        console.log("Copying file " + arg.from + " to " + arg.to)
-        bar.addFile(arg.from, arg.to, options, err => callback(err, bar));
-    };
-
-    let mount = function (bar, arg, options, callback) {
-        if (typeof options === 'function'){
-            callback = options;
-            options = undefined
-        }
-
-        readFile(arg.seed_path, (err, data) => {
-            if (err)
-                return callback(err);
-            let seed = data.toString();
-            console.log("Mounting " + arg.seed_path + " with seed " + seed + " to " + arg.mount_point);
-            bar.mount(arg.mount_point, seed, err => callback(err, bar));
-        });
-    };
-
-    let mount_folders = function (bar, arg, callback) {
-        let base_path = arg.seed_path.split("*");
-        let names = fs.readdirSync(base_path[0]);
-        let arguments = names.map(n => {
-            return {
-                "seed_path": arg.seed_path.replace("*", n),
-                "mount_point": arg.mount_point.replace("*", n)
-            };
-        });
-        execute(bar, mount, arguments, callback);
-    };
-
-    let evaluate_mount = function(bar, cmd, callback){
-        let arguments = {
-            "seed_path": cmd[0],
-            "mount_point": cmd[1]
-        };
-
-        if (!arguments.seed_path.match(/[\\/]\*[\\/]/))
-            mount(bar, arguments, callback);             // single mount
-        else
-            mount_folders(bar, arguments, callback);     // folder mount
-    };
+    const _varStore = varStore || new (require('./commands/VarStore'))();
 
     let createDossier = function (conf, commands, callback) {
         console.log("creating a new dossier...")
-        resolver.createDSU(keyssi.createTemplateSeedSSI(conf.domain), (err, bar) => {
+        _getResolver().createDSU(_getKeySSISpace().createTemplateSeedSSI(conf.domain), (err, bar) => {
             if (err)
                 return callback(err);
             updateDossier(bar, conf, commands, callback);
         });
     };
 
-    let readFile = function (filePath, callback) {
-        fs.readFile(filePath, (err, content) => {
-            if (err || content.length === 0)
-                return callback(err);
+    /**
+     * Writes to a file on the filesystem
+     * @param filePath
+     * @param data
+     * @param callback
+     */
+    const writeFile = function(filePath, data, callback){
+        new (_getByName('createfile'))(_varStore).execute([filePath, data], (err) => err
+            ? callback(err)
+            : callback(undefined, data));
+    }
 
-            callback(undefined, content.toString());
-        })
-    };
+    /**
+     * Reads a file from the filesystem
+     * @param filePath
+     * @param callback
+     */
+    const readFile = function(filePath, callback){
+        new (_getByName('readfile'))(_varStore).execute(filePath, callback);
+    }
 
-    let writeFile = function (filePath, data, callback) {
-        fs.writeFile(filePath, data, (err) => {
-            if (err)
-                return callback(err);
-            callback(undefined, data.toString());
-        });
-    };
-
+    /**
+     * Stores the keySSI to the SEED file when no sourceDSU is provided
+     * @param {string} seed_path the path to store in
+     * @param {string} keySSI
+     * @param {function(err, KeySSI)} callback
+     */
     let storeKeySSI = function (seed_path, keySSI, callback) {
         writeFile(seed_path, keySSI, callback);
     };
 
-    let runCommand = function(bar, command, callback){
-        let cmd = command.split(/\s+/);
-        switch (cmd.shift().toLowerCase()){
-            case operations.DELETE:
-                execute(bar, del, cmd, callback);
-                break;
-            case operations.ADD_FOLDER:
-                execute(bar, addFolder(), cmd, callback);
-                break;
-            case operations.ADD_FILE:
-                let arg = {
-                    "from": cmd[0],
-                    "to": cmd[1]
-                }
-                addFile(bar, arg, callback);
-                break;
-            case operations.MOUNT:
-                evaluate_mount(bar, cmd, callback)
-                break;
-            default:
-                return callback(new Error("Invalid operation requested: " + command));
-        }
+    /**
+     * Runs an operation
+     * @param {Archive} bar
+     * @param {string|string[]} command
+     * @param {string[]} next the remaining commands to be executed
+     * @param {function(err, Archive)} callback
+     */
+    let runCommand = function(bar, command, next, callback){
+        let args = command.split(/\s+/);
+        const cmdName = args.shift();
+        const cmd = _getByName(cmdName);
+        return cmd
+            ? new (cmd)(_varStore, this.source).execute(args, bar, next, callback)
+            : callback(`Command not recognized: ${cmdName}`);
     };
 
+    /**
+     * Retrieves the KeysSSi after save (when applicable)
+     * @param {Archive} bar
+     * @param {object} cfg is no sourceDSU is provided must contain a seed field
+     * @param {function(err, KeySSI)} callback
+     */
     let saveDSU = function(bar, cfg, callback){
         bar.getKeySSIAsString((err, barKeySSI) => {
             if (err)
                 return callback(err);
+            if(sourceDSU || cfg.skipFsWrite)
+                return callback(undefined, barKeySSI);
             storeKeySSI(cfg.seed, barKeySSI, callback);
         });
     };
 
+    /**
+     * Run a sequence of {@link Command}s on the DSU
+     * @param {Archive} bar
+     * @param {object} cfg
+     * @param {string[]} commands
+     * @param {function(err, KeySSI)} callback
+     */
     let updateDossier = function(bar, cfg, commands, callback) {
         if (commands.length === 0)
             return saveDSU(bar, cfg, callback);
         let cmd = commands.shift();
-        runCommand(bar, cmd, (err, updated_bar) => {
+        runCommand(bar, cmd, commands,(err, updated_bar) => {
             if (err)
                 return callback(err);
             updateDossier(updated_bar, cfg, commands, callback);
         });
     };
 
-    this.buildDossier = function(cfg, commands, callback){
+    /**
+     * Builds s DSU according to it's building instructions
+     * @param {object|Archive} configOrDSU: can be a config file form octopus or the destination DSU when cloning.
+     *
+     *
+     * Example of config file:
+     * <pre>
+     *     {
+     *         seed: path to SEED file in fs
+     *     }
+     * </pre>
+     * @param {string[]|object[]} [commands]
+     * @param {function(err, KeySSI)} callback
+     */
+    this.buildDossier = function(configOrDSU, commands, callback){
         if (typeof commands === 'function'){
             callback = commands;
             commands = [];
         }
 
-        readFile(cfg.seed, (err, content) => {
-            if (err || content.length === 0)
-                return createDossier(cfg, commands, callback);
-
-            let keySSI;
+        let builder = function(keySSI){
             try {
-                keySSI = keyssi.parse(content.toString());
+                keySSI = _getKeySSISpace().parse(keySSI);
             } catch (err) {
                 console.log("Invalid keySSI");
-                return createDossier(cfg, commands, callback);
+                return createDossier(configOrDSU, commands, callback);
             }
 
-            if (keySSI.getDLDomain() !== cfg.domain) {
+            if (keySSI.getDLDomain() !== configOrDSU.domain) {
                 console.log("Domain change detected.");
-                return createDossier(cfg, commands, callback);
+                return createDossier(configOrDSU, commands, callback);
             }
 
-            let identifier = content.toString();
-            resolver.loadDSU(identifier, (err, bar) => {
+            _getResolver().loadDSU(keySSI, (err, bar) => {
                 if (err){
-                    console.log("DSU not available. Creating a new DSU for", identifier);
-                    return resolver.createDSU(identifier, {useSSIAsIdentifier: true}, (err, bar)=>{
-                        if(err){
+                    console.log("DSU not available. Creating a new DSU for", keySSI);
+                    return _getResolver().createDSU(keySII, {useSSIAsIdentifier: true}, (err, bar)=>{
+                        if(err)
                             return callback(err);
-                        }
-
-                        updateDossier(bar, cfg, commands, callback);
+                        updateDossier(bar, configOrDSU, commands, callback);
                     });
                 }
                 console.log("Dossier updating...");
-                updateDossier(bar, cfg, commands, callback);
+                updateDossier(bar, configOrDSU, commands, callback);
             });
+        }
+
+        if (configOrDSU.constructor && configOrDSU.constructor.name === 'Archive')
+            return updateDossier(configOrDSU, {skipFsWrite: true}, commands, callback);
+
+        readFile(configOrDSU.seed, (err, content) => {
+            if (err || content.length === 0)
+                return createDossier(configOrDSU, commands, callback);
+            builder(content.toString());
         });
     };
 };

--- a/dt/FileService.js
+++ b/dt/FileService.js
@@ -1,0 +1,120 @@
+/**
+ * @module dt
+ */
+
+/**
+ * Forked from PrivateSky
+ * Provides an environment independent file service to the {@link AppBuilderService}
+ */
+function FileService(options) {
+    const isBrowser = $$.environmentType === 'browser';
+
+    function constructUrlBase(prefix){
+        let url, protocol, host;
+        prefix = prefix || "";
+        let appName = '';
+        if (isBrowser){
+            let location = window.location;
+            const paths = location.pathname.split("/");
+            while (paths.length > 0) {
+                if (paths[0] === "") {
+                    paths.shift();
+                } else {
+                    break;
+                }
+            }
+            appName = paths[0];
+            protocol = location.protocol;
+            host = location.host;
+            url = `${protocol}//${host}/${prefix}${appName}`;
+            return url;
+        } else {
+            return `http://${options.hosts}/${prefix}${options.walletPath}`;
+        }
+    }
+
+    this.getWalletSeed = function(callback){
+        this.getAppSeed(options.slots.primary, callback);
+    }
+
+    this.getAppSeed = function(appName, callback){
+        this.getFile(appName, options.seedFileName, (err, data) => {
+            if (err)
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(err));
+           Utf8ArrayToStr(data, callback);
+        });
+    }
+
+    function doGet(url, options, callback){
+        if (typeof options === "function") {
+            callback = options;
+            options = {};
+        }
+
+        const http = require("opendsu").loadApi("http");
+        http.fetch(url, {
+            method: 'GET'
+        }).then((response) => {
+            return response.arrayBuffer().then((data) => {
+                if (!response.ok)
+                    return callback("array data failed")
+                callback(undefined, data);
+            }).catch(e => callback(e));
+        }).catch(err => callback(err));
+    }
+
+    /**
+     * Returns the content of a file as a uintArray
+     * @param {string} appName
+     * @param {string} fileName
+     * @param {function(err, U8intArray)} callback
+     */
+    this.getFile = function(appName, fileName, callback){
+        const suffix = `${appName}/${fileName}`;
+        const base = constructUrlBase();
+        const joiner = suffix && base[base.length - 1] !== '/' && suffix[0] !== '/'
+            ? '/'
+            : '';
+
+        let url = base + joiner + suffix;
+        doGet(url, callback);
+    };
+
+
+    /**
+     *
+     * @param innerFolder
+     * @param callback
+     */
+    this.getFolderContentAsJSON = function(innerFolder, callback){
+        if (typeof innerFolder === 'function'){
+            callback = innerFolder;
+            innerFolder = undefined;
+        }
+        let url = constructUrlBase("directory-summary/") + (innerFolder ? `/${innerFolder}` : '') ;
+        doGet(url, (err, data) => {
+            if (err)
+                return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(err));
+            Utf8ArrayToStr(data, callback);
+        });
+    }
+
+    /**
+     * Util method to convert Utf8Arrays to Strings in the browser
+     * (simpler methods fail for big content jsons)
+     * @param {U8intArray} array
+     * @param {function(err, string)} callback
+     */
+    function Utf8ArrayToStr(array, callback) {
+        if (!isBrowser)
+            return callback(undefined, array.toString());
+        var bb = new Blob([array]);
+        var f = new FileReader();
+        f.onload = function(e) {
+            callback(undefined, e.target.result);
+        };
+        f.readAsText(bb);
+    }
+}
+
+module.exports = FileService;

--- a/dt/FileService.js
+++ b/dt/FileService.js
@@ -72,7 +72,7 @@ function FileService(options) {
     this.getFile = function(appName, fileName, callback){
         const suffix = `${appName}/${fileName}`;
         const base = constructUrlBase();
-        const joiner = suffix && base[base.length - 1] !== '/' && suffix[0] !== '/'
+        const joiner = suffix !== '/' && base[base.length - 1] !== '/' && suffix[0] !== '/'
             ? '/'
             : '';
 

--- a/dt/commands/Command.js
+++ b/dt/commands/Command.js
@@ -1,0 +1,104 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+const { _err } = require('./utils');
+
+/**
+ * **Every Command must be registered under the index.js file in the commands folder**
+ * @param {VarStore} varStore
+ * @param {Archive|fs} [source]
+ * @param {boolean} [canRunIteratively] defines if the command can expect multiple arguments and run multiple times. defaults to false
+ * @class Command
+ * @abstract
+ */
+class Command {
+    constructor(varStore, source, canRunIteratively) {
+        if (typeof source === 'boolean'){
+            canRunIteratively = source;
+            source = undefined;
+        }
+        if (!varStore.checkVariables)
+            throw new Error('Cant happen')
+
+        this.varStore = varStore;
+        this.source = source;
+        this.canRunIteratively = !!canRunIteratively;
+    }
+
+    /**
+     * Parses the command text and executes the command onto the provided DSU
+     * @param {string[]|string} args the arguments of the command split into words
+     * @param {Archive|KeySSI} [bar] the destinationDSU or the keySSI
+     * @param {string[]} [next] the remaining commands
+     * @param {object} [options]
+     * @param {function(err, Archive|KeySSI|string|boolean)} callback
+     */
+    execute(args,bar, next, options, callback){
+        if (typeof options === 'function'){
+            callback = options;
+            options = undefined;
+        }
+        if (typeof next === 'function'){
+            callback = next;
+            options = undefined;
+            next = undefined;
+        }
+        if (callback === undefined){
+            callback = bar;
+            bar = undefined;
+        }
+        let self = this;
+        this._parseCommand(args, next, (err, parsedArgs) => {
+            if (err)
+                return _err(`Could not parse command ${args}`, err, callback);
+
+            // Tests against variables
+            if (self.varStore)
+                parsedArgs = self.varStore.checkVariables(parsedArgs);
+
+            if (!self.canRunIteratively || !(parsedArgs instanceof Array))
+                return self._runCommand(parsedArgs, bar, options, callback);
+
+            const iterator = function(args, callback){
+                let arg = parsedArgs.shift();
+                if (!arg)
+                    return callback(undefined, bar);
+                return self._runCommand(arg, bar, options, (err, dsu) => err
+                    ? _err(`Could iterate over Command ${self.constructor.name} with args ${JSON.stringify(arg)}`, err, callback)
+                    : iterator(args, callback));
+            }
+
+            iterator(args, callback);
+        });
+    }
+
+    /**
+     * Should be overridden by child classes if any argument parsing is required
+     *
+     * @param {string[]|string|boolean} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string|string[]|object)} callback
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        callback(undefined, command);
+    }
+
+    /**
+     * @param {string|object} arg the command argument
+     * @param {Archive} [bar]
+     * @param {object} options
+     * @param {function(err, Archive|KeySSI|string)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback){
+        throw new Error("Child classes must implement this");
+    }
+}
+
+module.exports = Command;

--- a/dt/commands/Registry.js
+++ b/dt/commands/Registry.js
@@ -1,0 +1,33 @@
+/**
+ * List of all available commands to the Dossier Builder
+ * Without being here, they can't be used
+ */
+const _availableCommands = {
+    addfile: require('./addFile'),
+    addfolder: require('./addFolder'),
+    createdsu: require('./createDSU'),
+    createfile: require('./createFile'),
+    define: require('./define'),
+    delete: require('./delete'),
+    derive: require('./derive'),
+    endwith: require('./endWith'),
+    genkey: require('./genKey'),
+    getidentifier: require('./getIndentifier'),
+    mount: require('./mount'),
+    objtoarray: require('./objToArray'),
+    readfile: require('./readFile'),
+    with: require('./with')
+};
+
+/**
+ * return the Command class by its name
+ * @param cmdName
+ * @return {Command} the command calls to be instanced
+ */
+const _getByName = function(cmdName){
+    if (cmdName in _availableCommands)
+        return _availableCommands[cmdName];
+    return undefined;
+}
+
+module.exports = _getByName;

--- a/dt/commands/VarStore.js
+++ b/dt/commands/VarStore.js
@@ -1,0 +1,44 @@
+/**
+ * @module commands
+ * A simple variable store
+ */
+
+
+const VarStore = function(){
+    const _memory = {};
+    let _hasVars = false;
+    const self = this;
+
+    this.define = function(name, value){
+        _memory[name] = value;
+        _hasVars = true;
+        console.log(`Variable ${name} defined as ${value}`)
+    }
+
+    const tryReplace = function(value){
+        for (let name in _memory)
+            if (value.includes(name)) {
+                value = value.replace(name, _memory[name]);
+                console.log(`Replaced variable ${name}`)
+            }
+        return value;
+    }
+
+    this.checkVariables = function(args){
+        if (!_hasVars)
+            return args;
+        if (typeof args === 'string')
+            return tryReplace(args);
+        if (args instanceof Array)
+            return args.map(a => self.checkVariables(a));
+        if (typeof args !== 'object')
+            return args;
+        const result = {};
+        Object.keys(args).forEach(k => {
+            result[k] = self.checkVariables(args[k]);
+        });
+        return result;
+    }
+}
+
+module.exports = VarStore;

--- a/dt/commands/addFile.js
+++ b/dt/commands/addFile.js
@@ -1,0 +1,87 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _err } = require('./utils');
+
+/**
+ * Copies a File from disk or from a source DSU when provided
+ *
+ * supports sourceDSU, defaults to fs
+ *
+ * Can run iteratively
+ *
+ * @class AddFileCommand
+ */
+class AddFileCommand extends Command{
+    constructor(varStore, source) {
+        super(varStore, source, true);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next discarded
+     * @param {function(err, string|object)} [callback] discarded
+     * @return {string|object} the command argument
+     * <pre>
+     *     {
+     *         from: (...),
+     *         to: (..)
+     *     }
+     * </pre>
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        callback(undefined, {
+            "from": command[0],
+            "to": command[1]
+        });
+    }
+
+    /**
+     * Copies a file, from disk or another DSU
+     * @param {object} arg
+     * <pre>
+     *     {
+     *         from: (...),
+     *         to: (..)
+     *     }
+     * </pre>
+     * @param {Archive} bar
+     * @param {object} options
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        if (!callback) {
+            callback = options;
+            options = undefined;
+        }
+
+        options = options || {encrypt: true, ignoreMounts: false}
+        console.log("Copying file " + arg.from + (this.source ? " from sourceDSU" : "") + " to " + arg.to);
+
+        if (!this.source)
+            return bar.addFile(arg.from, arg.to, options, err => err
+                ? _err(`Could not read from ${arg.from}`, err, callback)
+                : callback(undefined, bar));
+
+        this.source.readFile(arg.from, (err, data) => {
+            if (err)
+                return _err(`Could not read from ${arg.from}`, err, callback);
+            bar.writeFile(arg.to, data, err => err
+                ? _err(`Could not write to ${arg.to}`, err, callback)
+                : callback(undefined, bar));
+        });
+    }
+}
+
+module.exports = AddFileCommand;

--- a/dt/commands/addFolder.js
+++ b/dt/commands/addFolder.js
@@ -1,0 +1,66 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _err } = require('./utils');
+
+/**
+ * This command copies an entire folder from the filesystem onto the destination DSU
+ * (as a single brick for efficiency if I'm not mistaken)
+ *
+ * Does not Support sourceDSU (yet)
+ *
+ * Can run iteratively
+ *
+ * @class AddFolderCommand
+ */
+class AddFolderCommand extends Command {
+    constructor(varStore, source) {
+        super(varStore, source, false);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string|object)} [callback] for async versatility
+     * @return {string|object} the command argument
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        callback(undefined, command[0]);
+    }
+
+    /**
+     * @param {string|object} arg the command argument
+     * @param {Archive} bar
+     * @param {object} [options]
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback){
+        if (this.source){
+            console.log("The addFolder Method is not supported when reading from a sourceDSU");
+            callback(undefined, bar);
+        }
+        if (!callback) {
+            callback = options;
+            options = undefined;
+        }
+
+        options = options || {batch: false, encrypt: false};
+        console.log("Adding Folder " + '/' + arg)
+        bar.addFolder(arg, '/', options, err => err
+            ? _err(`Could not add folder at '${'/' + arg}'`, err, callback)
+            : callback(undefined, bar));
+    }
+}
+
+module.exports = AddFolderCommand;

--- a/dt/commands/createDSU.js
+++ b/dt/commands/createDSU.js
@@ -1,0 +1,190 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _err, _getResolver, DSU_TYPE, KEY_TYPE } = require('./utils');
+const genKey = require('./genKey');
+
+/**
+ * @param {DSU_TYPE} dsuType
+ * @return {KEY_TYPE}
+ */
+const _getKeyType = function(dsuType){
+    switch (dsuType){
+        case DSU_TYPE.CONST:
+            return KEY_TYPE.ARRAY;
+        case DSU_TYPE.WALLET:
+            return KEY_TYPE.WALLET;
+        case DSU_TYPE.SEED:
+            return KEY_TYPE.SEED;
+        default:
+            throw new Error(`Unsupported DSU Type`);
+    }
+}
+
+
+/**
+ * Creates an Arrays SSI off a secret list
+ *
+ * Adds options.hint to hit if available
+ * @param {string[]} arg
+ * @param {function(err, KeySSI)} callback
+ */
+_createSSI = function(varStore, arg, callback){
+    const argToArray = (arg) => {
+        return `${arg.type} ${arg.domain} ${typeof arg.args === 'string' ? arg.args : JSON.stringify(arg.hint ? {
+            hint: arg.hint,
+            args: arg.args
+        } : arg.args)}`.split(/\s+/);
+    }
+    new genKey(varStore).execute(argToArray(arg), callback);
+}
+
+
+/**
+ * Creates a DSU of an ArraySSI
+ * @param {string[]} arg
+ * @param {object} opts DSU Creation Options
+ * @param {function(err, Archive)} callback
+ */
+_createWalletDSU = function(varStore, arg, opts, callback){
+    _createSSI(varStore, arg, (err, keySSI) => {
+        _getResolver().createDSUForExistingSSI(keySSI, opts, (err, dsu) => {
+            if (err)
+                return _err(`Could not create wallet DSU`, err, callback);
+            callback(undefined, dsu);
+        });
+    });
+}
+
+/**
+ * Creates a DSU of an ArraySSI
+ * @param {string[]} arg String for Seed SSI
+ * @param {object} opts DSU Creation Options
+ * @param {function(err, Archive)} callback
+ */
+_createDSU = function(varStore, arg, opts, callback){
+    _createSSI(varStore, arg, (err, keySSI) => {
+        _getResolver().createDSU(keySSI, opts, (err, dsu) => {
+            if (err)
+                return _err(`Could not create DSU`, err, callback);
+            callback(undefined, dsu);
+        });
+    });
+}
+
+/**
+ * Creates a DSU of an ArraySSI
+ * @param {string[]} arg
+ * @param {object} opts DSU Creation Options
+ * @param {function(err, Archive)} callback
+ */
+_createConstDSU = function(varStore, arg,opts , callback){
+    _createSSI(varStore, arg, (err, keySSI) => {
+        _getResolver().createDSUForExistingSSI(keySSI, opts, (err, dsu) => {
+            if (err)
+                return _err(`Could not create const DSU`, err, callback);
+            callback(undefined, dsu);
+        });
+    });
+}
+
+_getDSUFactory = function(isConst, isWallet){
+    return isConst ? (isWallet ? _createWalletDSU : _createConstDSU) : _createDSU;
+}
+
+/**
+ * creates a new DSU of the provided type and with the provided key gen arguments
+ *
+ * @class CreateDSUCommand
+ */
+class CreateDSUCommand extends Command{
+    constructor(varStore, source) {
+        super(varStore, source, false);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next discarded
+     * @param {function(err, string|object)} [callback] discarded
+     * @return {string|object} the command argument
+     * <pre>
+     *     {
+     *         type: (...),
+     *         domain: (..)
+     *         args: {string[]|object},
+     *     }
+     * </pre>
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        try {
+            let arg = {
+                dsuType: command.shift(),
+                domain: command.shift(),
+                args: command.length === 1 ? command[0] : JSON.parse(command.join(' '))
+            }
+            arg.type = _getKeyType(arg.dsuType);
+            if (typeof arg.args === 'object' && arg.args.args){
+                arg.hint = arg.args.hint;
+                arg.args = arg.args.args;
+            }
+            callback(undefined, arg)
+        } catch (e){
+            _err(`could not parse json ${command}`, e, callback);
+        }
+    }
+
+    /**
+     * Copies a file, from disk or another DSU
+     * @param {object} arg
+     * <pre>
+     *     {
+     *         from: (...),
+     *         to: (..)
+     *     }
+     * </pre>
+     * @param {Archive} bar
+     * @param {object} options
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        if(!callback){
+            callback = options;
+            options = bar;
+            bar = undefined;
+        }
+        if (typeof options === 'function'){
+            callback = options;
+            options = undefined;
+        }
+        const cb = function(err, dsu){
+            if (err)
+                return _err(`Could not create DSU with ${JSON.stringify(arg)}`, err, callback);
+            console.log(`${arg.dsuType} DSU created`);
+            callback(undefined, dsu);
+        }
+
+        switch (arg.dsuType){
+            case DSU_TYPE.SEED:
+                return _createDSU(this.varStore, arg, cb)
+            case DSU_TYPE.CONST:
+                return _createConstDSU(this.varStore, arg, cb);
+            case DSU_TYPE.WALLET:
+                return _createWalletDSU(this.varStore, arg, cb);
+            default:
+                callback(`Unsupported key type`);
+        }
+    }
+}
+
+module.exports = CreateDSUCommand;

--- a/dt/commands/createFile.js
+++ b/dt/commands/createFile.js
@@ -1,0 +1,65 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const {_getFS, _err} = require('./utils');
+
+/**
+ * Creates a file with the provided content on the destination DSU
+ * (similar to a touch command with added content)
+ *
+ * @class CreateFileCommand
+ */
+class CreateFileCommand extends Command{
+    constructor(varStore) {
+        super(varStore);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string|object)} [callback] for async versatility
+     * @return {string|object} the command argument
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        command = typeof command === 'string' ? command.split(' ') : command;
+        callback(undefined,  {
+            path: command.shift(),
+            content: command.join(' ')
+        });
+    }
+
+    /**
+     * Writes a file
+     * @param {object} arg the command argument
+     * <pre>
+     *     {
+     *         path: (...),
+     *         content: (..)
+     *     }
+     * </pre>
+     * @param {Archive|fs} bar
+     * @param {object} options
+     * @param {function(err, string)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback){
+        if (typeof options === 'function') {
+            callback = options;
+            options = undefined;
+        }
+        if (!bar)
+            bar = _getFS();
+        options = options || {encrypt: true, ignoreMounts: false};
+        bar.writeFile(arg.path, arg.content, options, (err) => err
+            ? _err(`Could not create file at ${arg.path}`, err, callback)
+            : callback(undefined, bar));
+    }
+}
+
+module.exports = CreateFileCommand;

--- a/dt/commands/define.js
+++ b/dt/commands/define.js
@@ -6,7 +6,7 @@
 /**
  */
 const Command = require('./Command');
-const { _err, VAR, CMD} = require('./utils');
+const { _err } = require('./utils');
 
 /**
  * Defines a variable that can later be used in the script

--- a/dt/commands/define.js
+++ b/dt/commands/define.js
@@ -1,0 +1,81 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _err, VAR, CMD} = require('./utils');
+
+/**
+ * Defines a variable that can later be used in the script
+ *
+ * @class DefineCommand
+ */
+class DefineCommand extends Command {
+    constructor(varStore) {
+        super(varStore);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string|object)} [callback] for async versatility
+     * @return {string|object} the command argument
+     * @protected
+     */
+    _parseCommand(command, next, callback) {
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+
+        callback(undefined, {
+            varName: command.shift(),
+            command: command
+        });
+    }
+
+    /**
+     * @param {string[]|object} arg the command argument
+     * @param {Archive} bar
+     * @param {object} options
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = undefined;
+        }
+        let self = this;
+        const _getByName = require('./Registry');
+
+        if (!_getByName(arg.command[0])){
+            this.varStore.define(arg.varName, arg.command);
+            console.log(`Define executed: ${arg.command}`);
+            return callback(undefined, bar);
+        }
+
+        const parseCommand = function(command, callback){
+            const cmdName = command.shift();
+            const actualCmd = _getByName(cmdName);
+            if (!actualCmd)
+                return callback(`Could not find command`);
+            callback(undefined, cmdName, actualCmd, command);
+        }
+
+        return parseCommand(arg.command, (err, cmdName, command, args) => err
+            ? _err(`Could not parse Command`, err, callback)
+            : new (command)(self.varStore, self.source).execute(args, bar, (err, result) => {
+                if (err)
+                    return _err(`Could not obtain result`, err, callback);
+                this.varStore.define(arg.varName, result);
+                console.log(`Define executed: ${result}`);
+                callback(undefined, bar);
+            }));
+    }
+}
+
+module.exports = DefineCommand;

--- a/dt/commands/delete.js
+++ b/dt/commands/delete.js
@@ -1,0 +1,53 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+
+/**
+ */
+const Command = require('./Command');
+const { _err } = require('./utils');
+
+/**
+ * Deletes everything in the specified path of the DSU
+ *
+ * @class DeleteCommand
+ */
+class DeleteCommand extends Command {
+    constructor(varStore) {
+        super(varStore,undefined, false);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string|object)} [callback] for async versatility
+     * @return {string|object} the command argument
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        callback(undefined, command[0]);
+    }
+
+    /**
+     * @param {string} arg
+     * @param {Archive} bar
+     * @param {object} [options]
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback){
+        if (typeof options === 'function'){
+            callback = options;
+            options = {}
+        }
+        options = options || {ignoreMounts: false};
+        console.log("Deleting " + arg);
+        bar.delete(arg, options, err => err
+            ? _err(`Could not delete path '${arg}'`, err, callback)
+            : callback(undefined, bar));
+    }
+}
+
+module.exports = DeleteCommand;

--- a/dt/commands/derive.js
+++ b/dt/commands/derive.js
@@ -1,0 +1,54 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _getKeySSISpace, _err } = require('./utils');
+
+/**
+ * Derives the provided keySSI
+ *
+ * @class DeriveCommand
+ */
+class DeriveCommand extends Command{
+    constructor(varStore) {
+        super(varStore);
+    }
+
+    _parseCommand(command, next, callback) {
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        callback(undefined, command
+            ? !(command === 'false' || command[0] === 'false')
+            : true);
+    }
+
+    /**
+     * derives the provided keySSI (in the source object)
+     * @param {object} arg unused
+     * @param {KeySSI} bar
+     * @param {object} options unsused
+     * @param {function(err, KeySSI)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        if (!callback) {
+            callback = options;
+            options = undefined;
+        }
+
+        try{
+            const keySSI = _getKeySSISpace().parse(bar).derive();
+            callback(undefined, arg ? keySSI.getIdentifier() : keySSI);
+        } catch (e) {
+            _err(`Could not derive Key ${JSON.stringify(bar)}`, e, callback)
+        }
+    }
+}
+
+module.exports = DeriveCommand;

--- a/dt/commands/endWith.js
+++ b/dt/commands/endWith.js
@@ -1,0 +1,51 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+
+/**
+ * Allows for more complex logic by allowing you to control the output/input for commands
+ * while keeping the commands readable
+ *
+ * basically sets whatever the result of the with operation into the source portion until it finds the endwith command
+ *
+ * @class EndWithCommand
+ */
+class EndWithCommand extends Command{
+    constructor(varStore) {
+        super(varStore);
+    }
+
+    /**
+     * Returns the source object
+     * @param {string[]|object} arg unused
+     * @param {Archive} bar unused
+     * @param {object} options unused
+     * @param {function(err, Archive|KeySSI)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback){
+        if (!callback) {
+            callback = options;
+            options = undefined;
+        }
+        if (!callback){
+            callback = bar;
+            bar = arg;
+            arg = undefined;
+        }
+
+        // return whatever the object was
+        if (!bar)
+            return callback(`Nothing to return. should not be possible`);
+
+        console.log(`Ending With command. Returning to ${JSON.stringify(bar)}`);
+        callback(undefined, bar);
+    }
+}
+
+module.exports = EndWithCommand;

--- a/dt/commands/genKey.js
+++ b/dt/commands/genKey.js
@@ -1,0 +1,148 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _err, _getKeySSISpace, KEY_TYPE } = require('./utils');
+
+/**
+ * Generates a KeySSI
+ *
+ * @class GenKeyCommand
+ */
+class GenKeyCommand extends Command {
+    constructor(varStore) {
+        super(varStore,undefined, false);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string|object)} [callback] for async versatility
+     * @return {string|object} the command argument
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+
+        const tryParseJson = function(text){
+            try {
+                let parsedArgs = JSON.parse(text);
+                if (parsedArgs && typeof parsedArgs === 'object')
+                    return parsedArgs;
+                return text;
+            } catch (e) {
+                // The argument is just a string. leave it be
+                return text;
+            }
+        }
+
+        try {
+            let arg = {
+                type: command.shift(),
+                domain: command.shift(),
+                args: tryParseJson(command.shift())
+            }
+
+            if (typeof arg.args === 'object' && arg.args.args){
+                arg.hint = arg.args.hint;
+                arg.args = tryParseJson(arg.args.args);
+            }
+            callback(undefined, arg);
+        } catch (e){
+            _err(`could not parse json ${command}`, e, callback);
+        }
+    }
+
+    /**
+     * Creates an Arrays SSI off a secret list
+     *
+     * Adds options.hint to hit if available
+     * @param {object} args
+     * @param {function(err, ArraySSI)} callback
+     * @private
+     */
+    _createArraySSI = function(args, callback){
+        const key = _getKeySSISpace().createArraySSI(args.domain, args.args, 'v0', args.hint ? JSON.stringify(args.hint) : undefined);
+        callback(undefined, key);
+    }
+
+    /**
+     * Creates a Wallet SSI off a secret list
+     *
+     * Adds options.hint to hit if available
+     * @param {object} args
+     * @param {function(err, ArraySSI)} callback
+     */
+    _createWalletSSI = function(args, callback){
+        const key = _getKeySSISpace().createTemplateWalletSSI(args.domain, args.args, 'v0', args.hint ? JSON.stringify(args.hint) : undefined);
+        callback(undefined, key);
+    }
+
+    /**
+     * Creates an Arrays SSI off a secret list
+     *
+     * Adds options.hint to hit if available
+     * @param {object} args
+     * @param {function(err, TemplateSeedSSI)} callback
+     */
+    _createSSI = function(args, callback){
+        const key = _getKeySSISpace().createTemplateSeedSSI(args.domain, args.args, undefined, 'v0', args.hint ? JSON.stringify(args.hint) : undefined);
+        callback(undefined, key);
+    }
+
+    /**
+     * Copies a file, from disk or another DSU
+     * @param {object} arg
+     * <pre>
+     *     {
+     *         type: (...),
+     *         domain: (..),
+     *         args: []| {
+     *                  hint: (..)
+     *                  args: []
+     *         }
+     *     }
+     * </pre>
+     * @param {Archive} bar unused
+     * @param {object} options unused
+     * @param {function(err, KeySSI)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        if(!callback){
+            callback = options;
+            options = bar;
+            bar = undefined;
+        }
+        if (typeof options === 'function'){
+            callback = options;
+            options = undefined;
+        }
+        const cb = function(err, keySSI){
+            if (err)
+                return _err(`Could not create keySSI with ${JSON.stringify(arg)}`, err, callback);
+            console.log(`${arg.type} KeySSI created with SSI ${keySSI.getIdentifier()}`)
+            callback(undefined, keySSI);
+        }
+
+        switch (arg.type){
+            case KEY_TYPE.SEED:
+                return this._createSSI(arg, cb)
+            case KEY_TYPE.ARRAY:
+                return this._createArraySSI(arg, cb);
+            case KEY_TYPE.WALLET:
+                return this._createWalletSSI(arg, cb);
+            default:
+                callback(`Unsupported key type`);
+        }
+    }
+}
+
+module.exports = GenKeyCommand;

--- a/dt/commands/getIndentifier.js
+++ b/dt/commands/getIndentifier.js
@@ -1,0 +1,71 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _err } = require('./utils');
+
+/**
+ * Returns the identifier for the current source object
+ *
+ * @class GetIdentifierCommand
+ */
+class GetIdentifierCommand extends Command{
+    constructor(varStore) {
+        super(varStore);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next discarded
+     * @param {function(err, boolean)} callback
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        callback(undefined, command
+            ? !(command === 'false' || command[0] === 'false')
+            : true);
+    }
+
+    /**
+     * derives the provided keySSI
+     * @param {boolean} arg identifier as string (defaults to false)
+     * @param {Archive|KeySSI} bar
+     * @param {object} options unused
+     * @param {function(err, string|KeySSI)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        if (!callback) {
+            callback = options;
+            options = undefined;
+        }
+        if (!bar.getIdentifier && !bar.getKeySSIAsString)
+            return callback(`The object cannot be derived. It is a KeySSI or a DSU?`);
+
+        // if its a dsu
+        if (bar.constructor && bar.constructor.name === 'Archive')
+            return (arg ? bar.getKeySSIAsString : bar.getKeySSIAsObject)((err, identifier) => err
+                ? _err(`Could not get identifier`, err, callback)
+                : callback(undefined, identifier));
+
+        // if its a KeySSI
+        try{
+            let identifier = arg ? bar.getIdentifier() : bar;
+            if (!identifier)
+                return callback(`Could not get identifier`);
+            callback(undefined, identifier);
+        } catch (e){
+            _err(`Could not get identifier`, e, callback);
+        }
+    }
+}
+
+module.exports = GetIdentifierCommand;

--- a/dt/commands/index.js
+++ b/dt/commands/index.js
@@ -1,0 +1,22 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+module.exports = {
+    AddFileCommand: require('./addFile'),
+    AddFolderCommand: require('./addFolder'),
+    CreateDSUCommand: require('./createDSU'),
+    CreateFileCommand: require('./createFile'),
+    DefineCommand: require('./define'),
+    DeleteCommand: require('./delete'),
+    DeriveCommand: require('./derive'),
+    EndWithCommand: require('./endWith'),
+    GenKeyCommand: require('./genKey'),
+    GetIdentifierCommand: require('./getIndentifier'),
+    MountCommand: require('./mount'),
+    ObjToArrayCommand: require('./objToArray'),
+    ReadFileCommand: require('./readFile'),
+    WithCommand: require('./with'),
+    _getByName: require('./Registry')
+}

--- a/dt/commands/mount.js
+++ b/dt/commands/mount.js
@@ -1,0 +1,121 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const ReadFileCommand = require('./readFile');
+const { _err, _getFS, _getKeySSISpace } = require('./utils');
+
+/**
+ * Mounts a DSU onto the provided path
+ *
+ * @class MountCommand
+ */
+class MountCommand extends Command{
+    constructor(varStore, source) {
+        super(varStore, source, true);
+        if (!source)
+            this._getFS = require('./utils');
+    }
+
+    /**
+     * Lists all the mounts in the provided pattern, either via fs or source dsu
+     * @param {object} arg
+     * @param {function(err, string[])} callback
+     * @private
+     */
+    _listMounts(arg, callback){
+        let self = this;
+        let basePath = arg.seed_path.split("*");
+        const listMethod = this.source ? this.source.listMountedDSUs : _getFS().readdir;
+        listMethod(basePath[0], (err, args) => err
+            ? _err(`Could not list mounts`, err, callback)
+            : callback(undefined, self._transform_mount_arguments(arg, args)));
+    }
+
+    /**
+     * handles the difference between the mount arguments in the 2 cases (with/without sourceDSU)
+     * @param arg
+     * @param args
+     * @return {*}
+     * @private
+     */
+    _transform_mount_arguments(arg, args){
+        return this.source
+            ? args.map(m => {
+                return {
+                    "seed_path": m.identifier,
+                    "mount_point": m.path
+                }
+            })
+            : args.map(n => {
+                return {
+                    "seed_path": arg.seed_path.replace("*", n),
+                    "mount_point": arg.mount_point.replace("*", n)
+                };
+            });
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string|string[]|object)} callback
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        let arg = {
+            "seed_path": command[0],
+            "mount_point": command[1]
+        };
+
+        if (!arg.seed_path.match(/[\\/]\*[\\/]/))
+            return callback(undefined, arg);   // single mount
+        // multiple mount
+        this._listMounts(arg, callback);
+    }
+
+    /**
+     * Mounts a DSu onto a path
+     * @param {object} arg
+     * <pre>
+     *     {
+     *         seed_path: (...),
+     *         mount_point: (..)
+     *     }
+     * </pre>
+     * @param {Archive} [bar]
+     * @param {object} options
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        let self = this;
+        if (typeof options === 'function'){
+            callback = options;
+            options = undefined;
+        }
+
+        const doMount = function(seed, callback){
+            console.log("Mounting seed " + seed + " to " + arg.mount_point);
+            bar.mount(arg.mount_point, seed, err => err
+                ? _err(`Could not perform mount of ${seed} at ${arg.seed_path}`, err, callback)
+                : callback(undefined, bar));
+        };
+        try {
+            if (_getKeySSISpace().parse(arg.seed_path))
+                return doMount(arg.seed_path, callback);
+        } catch (e){
+            new ReadFileCommand(this.varStore, this.source).execute(arg.seed_path, (err, seed) => {
+                if (err)
+                    return _err(`Could not read seed from ${arg.seed_path}`, err, callback);
+                seed = seed.toString();
+                doMount(seed, callback);
+            });
+        }
+    }
+}
+
+module.exports = MountCommand;

--- a/dt/commands/objToArray.js
+++ b/dt/commands/objToArray.js
@@ -1,0 +1,56 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _err } = require('./utils');
+
+/**
+ * Util Command to convert objects to and array with their values
+ * @class ObjToArrayCommand
+ */
+class ObjToArrayCommand extends Command{
+    constructor(varStore, source) {
+        super(varStore, source, false);
+    }
+
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        callback(undefined, typeof command === 'string' ? command : command.shift());
+    }
+
+    /**
+     * Outputs all args to console
+     * @param {object} arg
+     * @param {Archive} bar
+     * @param {object} options
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        if (!callback) {
+            callback = options;
+            options = undefined;
+        }
+        try{
+            const obj = JSON.parse(arg);
+            if (typeof obj !== 'object')
+                return callback(`Provided argument is not an object`);
+            if (Array.isArray(obj)){
+                console.log(`Object was already an array ${arg}`);
+                callback(undefined, obj);
+            }
+            callback(undefined, JSON.stringify(Object.values(obj)));
+        } catch (e) {
+            _err(`Could not parse object. Was it a valid json?`, e, callback);
+        }
+    }
+}
+
+module.exports = ObjToArrayCommand;

--- a/dt/commands/readFile.js
+++ b/dt/commands/readFile.js
@@ -1,0 +1,69 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _getFS, _err } = require('./utils')
+
+/**
+ * Reads The contents of a file from disk or from a sourceDSU
+ *
+ * supports sourceDSU
+ *
+ * @class ReadFileCommand
+ */
+class ReadFileCommand extends Command{
+    constructor(varStore, source) {
+        super(varStore, source ? source : _getFS());
+        this.dataToString = !source;
+    }
+
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        callback(undefined, typeof command === 'string' ? command : command[0]);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string)} callback
+     * @protected
+     */
+    _parseCommand(command, next, callback){
+        if (!callback){
+            callback = next;
+            next = undefined;
+        }
+        callback(undefined, command);
+    }
+
+    /**
+     * @param {Archive} bar unused in this method
+     * @param {string} arg the command argument
+     * @param {object} options
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback){
+        if (typeof options === 'function'){
+            callback = options;
+            options = undefined;
+        }
+        if (!callback) {
+            callback = bar;
+            bar = undefined
+        }
+
+        this.source.readFile(arg, (err, data) => err
+            ? _err(`Could not read file at ${arg}`, err, callback)
+            : callback(undefined, this.dataToString ? data : data.toString()));
+    }
+}
+
+module.exports = ReadFileCommand;

--- a/dt/commands/readFile.js
+++ b/dt/commands/readFile.js
@@ -21,14 +21,6 @@ class ReadFileCommand extends Command{
         this.dataToString = !source;
     }
 
-    _parseCommand(command, next, callback){
-        if (!callback){
-            callback = next;
-            next = undefined;
-        }
-        callback(undefined, typeof command === 'string' ? command : command[0]);
-    }
-
     /**
      * @param {string[]|string} command the command split into words
      * @param {string[]} next the following Commands

--- a/dt/commands/utils.js
+++ b/dt/commands/utils.js
@@ -1,0 +1,87 @@
+/**
+ * @module Commands
+ */
+
+/**
+ * cache of node's fs object
+ */
+
+let  _fileSystem = undefined;
+
+/**
+ * Caches and returns node's fs object if the environment is right
+ * @return {fs}
+ */
+const _getFS = function(){
+    if ($$.environmentType !== 'nodejs')
+        throw new Error("Wrong environment for this function. Please make sure you know what you are doing...");
+    if (!_fileSystem)
+        _fileSystem = require('fs');
+    return _fileSystem;
+}
+
+/**
+ * Provides Util functions and Methods as well as caching for the open DSU resolver and {@Link DSUBuilder}
+ */
+
+let resolver, keyssi;
+
+/**
+ * Wrapper around
+ * <pre>
+ *     OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(msg, err));
+ * </pre>
+ * @param msg
+ * @param err
+ * @param callback
+ * @protected
+ */
+const _err = function(msg, err, callback){
+    return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(msg, err));
+}
+
+/**
+ * for singleton use
+ * @returns {function} resolver api
+ */
+const _getResolver = function(){
+    if (!resolver)
+        resolver = require('opendsu').loadApi('resolver');
+    return resolver;
+}
+
+/**
+ * for singleton use
+ * @returns {function} keyssi api
+ */
+const _getKeySSISpace = function(){
+    if (!keyssi)
+        keyssi = require('opendsu').loadApi('keyssi');
+    return keyssi;
+}
+
+const KEY_TYPE = {
+    ARRAY: "array",
+    SEED: "seed",
+    WALLET: 'wallet'
+}
+
+const DSU_TYPE = {
+    CONST: "const",
+    WALLET: "wallet",
+    SEED: "seed"
+}
+
+const VAR = 'var';
+const CMD = 'cmd';
+
+module.exports = {
+    _getFS,
+    _getResolver,
+    _getKeySSISpace,
+    _err,
+    KEY_TYPE,
+    DSU_TYPE,
+    VAR,
+    CMD
+};

--- a/dt/commands/utils.js
+++ b/dt/commands/utils.js
@@ -72,16 +72,11 @@ const DSU_TYPE = {
     SEED: "seed"
 }
 
-const VAR = 'var';
-const CMD = 'cmd';
-
 module.exports = {
     _getFS,
     _getResolver,
     _getKeySSISpace,
     _err,
     KEY_TYPE,
-    DSU_TYPE,
-    VAR,
-    CMD
+    DSU_TYPE
 };

--- a/dt/commands/with.js
+++ b/dt/commands/with.js
@@ -6,7 +6,7 @@
 /**
  */
 const Command = require('./Command');
-const { _err, VAR, CMD } = require('./utils');
+const { _err } = require('./utils');
 const endCommand = 'endwith';
 const startCommand = 'with';
 

--- a/dt/commands/with.js
+++ b/dt/commands/with.js
@@ -1,0 +1,126 @@
+/**
+ * @module Commands
+ * @memberOf dt
+ */
+
+/**
+ */
+const Command = require('./Command');
+const { _err, VAR, CMD } = require('./utils');
+const endCommand = 'endwith';
+const startCommand = 'with';
+
+
+
+/**
+ * Allows for more complex logic by allowing you to control the output/input for commands
+ * while keeping the commands readable
+ *
+ * basically sets whatever the result of the with operation into the source portion until it finds the endwith command
+ *
+ * @class WithCommand
+ */
+class WithCommand extends Command {
+    constructor(varStore, source) {
+        super(varStore, source);
+    }
+
+    /**
+     * @param {string[]|string} command the command split into words
+     * @param {string[]} next the following Commands
+     * @param {function(err, string|object)} [callback] for async versatility
+     * @return {string|object} the command argument
+     * @protected
+     */
+    _parseCommand(command, next, callback) {
+        if (!next)
+            throw new Error("No next defined");
+        const commandsToConsider = [command];
+        let cmd;
+        let count = 0;
+        while (!this._isEndCommand((cmd = next.shift())) && count === 0){
+            let c = cmd.split(/\s+/);
+            commandsToConsider.push(c);
+            if (this._isStartCommand(c[0]))
+                count++;
+            if (this._isEndCommand(c[0]))
+                count--;
+        }
+
+        commandsToConsider.push(cmd.split(/\s+/));
+        callback(undefined, commandsToConsider);
+    }
+
+    _isStartCommand(cmd){
+        return cmd.indexOf(startCommand) === 0;
+    }
+
+    _isEndCommand(cmd) {
+        return cmd.indexOf(endCommand) === 0;
+    }
+
+    /**
+     * @param {string[]} arg the command argument
+     * @param {Archive} bar
+     * @param {object} options
+     * @param {function(err, Archive)} callback
+     * @protected
+     */
+    _runCommand(arg, bar, options, callback) {
+        let self = this;
+        if (typeof options === 'function') {
+            callback = options;
+            options = undefined;
+        }
+        if (!callback){
+            callback = bar;
+            bar = undefined;
+        }
+        const _getByName = require('./Registry');
+
+        const parseCommand = function(command, callback){
+            const cmdName = command.shift();
+            const actualCmd = _getByName(cmdName);
+            if (!actualCmd)
+                return callback(`Could not find command`);
+            callback(undefined, cmdName, actualCmd, command);
+        }
+
+        const performWith = function(newSource, commands, callback){
+            const cmd = commands.shift();
+            if (!cmd)
+                return callback(`No endWith command found. this should not be possible`);
+            parseCommand(cmd, (err, cmdName, command, args) => {
+                if (err)
+                    return _err(`Could not parse the command ${cmd}`, err, callback);
+                if (cmdName === endCommand)
+                    return new command(self.varStore, self.source).execute(undefined, bar, callback);
+                new command(self.varStore, self.source).execute(args, newSource, (err, result) => {
+                    if (err)
+                        return _err(`Could not execute command ${cmdName}`, err, callback);
+                    console.log(`Command ${cmdName} executed with output ${JSON.stringify(result)}`);
+                    performWith(newSource, commands, callback);
+                });
+            });
+        }
+
+        const cmdOrVar = arg[0][0];
+        const cmd = _getByName(cmdOrVar);
+
+        if (!cmd){
+            console.log(`With VARIABLE executed: ${arg[0]}`);
+            return performWith(arg.shift().shift(), arg, callback);
+        }
+
+        parseCommand(arg.shift(), (err, cmdName, command, args) => err
+            ? _err(`Could not parse Command`, err, callback)
+            : new (command)(self.varStore, self.source).execute(args, (err, result) => {
+                if (err)
+                    return _err(`Could not obtain result`, err, callback);
+                console.log(`With COMMAND executed: ${JSON.stringify(result)}`);
+                performWith(result, arg, callback);
+            }));
+    }
+}
+
+module.exports = WithCommand;

--- a/dt/index.js
+++ b/dt/index.js
@@ -1,11 +1,24 @@
-/*
-html API space
-*/
+/**
+ * @module dt
+ */
 
-const getDossierBuilder = () => {
-    return new (require("./DossierBuilder"))()
+/**
+ * Provides a Environment Independent and Versatile Dossier Building API.
+ *
+ * Meant to be integrated into OpenDSU
+ */
+
+/**
+ * Returns a DossierBuilder Instance
+ * @param {Archive} [sourceDSU] should only be provided when cloning a DSU
+ * @return {DossierBuilder}
+ */
+const getDossierBuilder = (sourceDSU, ) => {
+    return new (require("./DossierBuilder"))(sourceDSU)
 }
 
 module.exports = {
-    getDossierBuilder
+    getDossierBuilder,
+    Commands: require('./commands'),
+    AppBuilderService: require('./AppBuilderService')
 }


### PR DESCRIPTION
fully functional but needs reviewed Documentation and there might be some leftover code.

(also there's a clone method in AppBuilderService that's meant to allows to clone a DSU's data before migrating to another dsu, but it's not mature yet. its not being used anywhere, so its ok)

The following command syntax in now acceptable besides the already existing in build.file:
```
define $ID$ -$Identity-
define $ENV$ -$Environment-

with createdsu seed traceability specificstring
    define $SEED$ getidentifier
    createfile info $ID$
endwith

createfile environment.json $ENV$
mount $SEED$ /id

with $SEED$
    define $READ$ derive
endwith

define $SECRETS$ objtoarray $ID$

with createdsu const traceability $SECRETS$
    mount $READ$ /id
    define $CONST$ getidentifier
endwith

mount $CONST$ /participant

with createdsu seed traceability fordb
    define $DB$ getidentifier
endwith

mount $DB$ /db

## WHOLESALER INIT SCRIPT
```
(note that this runs after the DSU instance has been built by the loader and the environment.json and identity.json have already been written to the DSU)