### PR TITLE
Fix double calling callback

### DIFF
--- a/error/index.js
+++ b/error/index.js
@@ -1,11 +1,14 @@
 function ErrorWrapper(message, err, otherErrors){
     let newErr = {};
-    if((err && err.message) || otherErrors) {
+
+    err = err || {};
+
+    if (err.message || otherErrors) {
         if (err.originalMessage) {
             newErr.originalMessage = err.originalMessage;
-        }else{
+        } else {
             newErr.originalMessage = err.message;
-            if(otherErrors){
+            if (otherErrors) {
                 if (typeof otherErrors === "string") {
                     newErr.originalMessage += otherErrors;
                 }
@@ -14,33 +17,31 @@ function ErrorWrapper(message, err, otherErrors){
                     otherErrors.forEach(e => newErr.originalMessage += `[${e.message}]`);
                 }
             }
-            if(typeof newErr.originalMessage === "string") {
+            if (typeof newErr.originalMessage === "string") {
                 newErr.originalMessage = newErr.originalMessage.replace(/\n/g, " ");
             }
         }
-    } else if (!err) {
-        err = {};
+
     }
 
-
-    try{
+    try {
         if (err.originalMessage) {
             newErr = new Error(message + `(${err.originalMessage})`);
             newErr.originalMessage = err.originalMessage;
-        }else{
+        } else {
             newErr = new Error(newErr.originalMessage);
             newErr.originalMessage = newErr.message;
         }
         throw newErr;
-    }catch (e) {
+    } catch (e) {
         newErr = e;
     }
     newErr.previousError = err;
     newErr.debug_message = message;
-    if(err){
+    if (err.stack) {
         newErr.debug_stack   = err.stack;
     }
-    if(otherErrors){
+    if (otherErrors) {
         newErr.otherErrors = otherErrors;
     }
     return newErr;

--- a/error/index.js
+++ b/error/index.js
@@ -18,7 +18,10 @@ function ErrorWrapper(message, err, otherErrors){
                 newErr.originalMessage = newErr.originalMessage.replace(/\n/g, " ");
             }
         }
+    } else if (!err) {
+        err = {};
     }
+
 
     try{
         if (err.originalMessage) {

--- a/utils/promise-runner.js
+++ b/utils/promise-runner.js
@@ -1,4 +1,5 @@
 const arrayUtils = require("./array");
+const { OpenDSUSafeCallback, createOpenDSUErrorWrapper } = require('./../error')
 
 function validateMajorityRunAllWithSuccess(successResults, errorResults, totalCount) {
   const successCount = successResults.length;
@@ -28,7 +29,7 @@ function runSinglePromise(executePromise, promiseInput) {
     });
 }
 
-function runAll(listEntries, executeEntry, validateResults, callback, debugInfo) {
+async function runAll(listEntries, executeEntry, validateResults, callback, debugInfo) {
   if (typeof validateResults !== "function") {
     validateResults = validateMajorityRunAllWithSuccess;
   }
@@ -36,34 +37,37 @@ function runAll(listEntries, executeEntry, validateResults, callback, debugInfo)
   const allInitialExecutions = listEntries.map((entry) => {
     return runSinglePromise(executeEntry, entry);
   });
-  Promise.all(allInitialExecutions)
-    .then((results) => {
-      const successExecutions = results.filter((run) => run.success);
-      let errorExecutions = results.filter((run) => !run.success);
-      errorExecutions = errorExecutions.map(e => {
-        if (e.error && e.error.error) {
-          return e.error.error;
-        }else {
-          return e;
-        }
-      });
-      const isConsideredSuccessfulRun = validateResults(successExecutions, errorExecutions);
-      if (isConsideredSuccessfulRun) {
-        const successExecutionResults = successExecutions.map((run) => run.result);
-        return callback(null, successExecutionResults);
-      }
 
-      let baseError = debugInfo;
-      if(errorExecutions.length){
-        if(baseError){
-          baseError = createOpenDSUErrorWrapper("Error found during runAll", errorExecutions[0], errorExecutions, debugInfo);
-        }
-      }
-      return callback(createOpenDSUErrorWrapper("FAILED to runAll " , baseError));
-    })
-    .catch(( error) => {
-      callback(error)
-    });
+  let results;
+
+  try {
+    results = await Promise.all(allInitialExecutions)
+  } catch (e) {
+    return callback(e);
+  }
+
+  const successExecutions = results.filter((run) => run.success);
+  let errorExecutions = results.filter((run) => !run.success);
+  errorExecutions = errorExecutions.map(e => {
+    if (e.error && e.error.error) {
+      return e.error.error;
+    }else {
+      return e;
+    }
+  });
+  const isConsideredSuccessfulRun = validateResults(successExecutions, errorExecutions);
+  if (isConsideredSuccessfulRun) {
+    const successExecutionResults = successExecutions.map((run) => run.result);
+    return callback(null, successExecutionResults);
+  }
+
+  let baseError = debugInfo;
+  if(errorExecutions.length){
+    if(baseError){
+      baseError = OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Error found during runAll", errorExecutions[0], errorExecutions, debugInfo));
+    }
+  }
+  return OpenDSUSafeCallback(callback)((createOpenDSUErrorWrapper("FAILED to runAll " , baseError)));
 }
 
 function runOneSuccessful(listEntries, executeEntry, callback, debugInfo) {
@@ -95,7 +99,7 @@ function runOneSuccessful(listEntries, executeEntry, callback, debugInfo) {
   executeForSingleEntry(entry);
 }
 
-function runEnoughForMajority(listEntries, executeEntry, initialRunCount, validateResults, callback, debugInfo) {
+async function runEnoughForMajority(listEntries, executeEntry, initialRunCount, validateResults, callback, debugInfo) {
   const totalCount = listEntries.length;
 
   if (!initialRunCount || typeof initialRunCount !== "number") {
@@ -112,7 +116,7 @@ function runEnoughForMajority(listEntries, executeEntry, initialRunCount, valida
   const initialEntries = listEntries.slice(0, initialRunCount);
   const remainingEntries = listEntries.slice(initialRunCount);
 
-  const checkAllExecutedRunResults = () => {
+  const checkAllExecutedRunResults = async () => {
     const successExecutions = allExecutedRunResults.filter((run) => run.success);
     const errorExecutions = allExecutedRunResults.filter((run) => !run.success);
 
@@ -128,27 +132,22 @@ function runEnoughForMajority(listEntries, executeEntry, initialRunCount, valida
     }
 
     const nextEntry = remainingEntries.shift();
-    runSinglePromise(executeEntry, nextEntry)
-      .then((nextEntryResult) => {
-        allExecutedRunResults.push(nextEntryResult);
-        checkAllExecutedRunResults();
-      })
-      .catch(() => {
-        // runSinglePromise already makes sure no catch is thrown
-        // put to ignore nodejs unhandled execution warning
-      });
+
+    const nextEntryResult = await runSinglePromise(executeEntry, nextEntry);
+    allExecutedRunResults.push(nextEntryResult);
+    checkAllExecutedRunResults();
   };
 
   const allInitialExecutions = initialEntries.map((entry) => {
     return runSinglePromise(executeEntry, entry);
   });
 
-  Promise.all(allInitialExecutions)
-    .then((results) => {
-      allExecutedRunResults = results;
-      checkAllExecutedRunResults();
-    })
-    .catch((error) => callback(error));
+  try {
+    allExecutedRunResults = await Promise.all(allInitialExecutions);
+  } catch (e) {
+    return callback(e);
+  }
+  checkAllExecutedRunResults();
 }
 
 module.exports = {

--- a/utils/promise-runner.js
+++ b/utils/promise-runner.js
@@ -64,7 +64,7 @@ async function runAll(listEntries, executeEntry, validateResults, callback, debu
   let baseError = debugInfo;
   if(errorExecutions.length){
     if(baseError){
-      baseError = OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Error found during runAll", errorExecutions[0], errorExecutions, debugInfo));
+      baseError = OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper("Error found during runAll", errorExecutions[0], errorExecutions));
     }
   }
   return OpenDSUSafeCallback(callback)((createOpenDSUErrorWrapper("FAILED to runAll " , baseError)));

--- a/utils/promise-runner.js
+++ b/utils/promise-runner.js
@@ -76,19 +76,20 @@ function runOneSuccessful(listEntries, executeEntry, callback, debugInfo) {
 
   const entry = availableListEntries.shift();
 
-  const executeForSingleEntry = (entry) => {
-    return executeEntry(entry)
-      .then((result) => {
-        return callback(null, result);
-      })
-      .catch((err) => {
-        if (!availableListEntries.length) {
-          return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to execute entry`, err));
-        }
+  const executeForSingleEntry = async (entry) => {
+      let result;
+      try {
+          result = await executeEntry(entry);
+      } catch (e) {
+          if (!availableListEntries.length) {
+              return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to execute entry`, err));
+          }
 
-        const nextEntry = availableListEntries.shift();
-        executeForSingleEntry(nextEntry);
-      });
+          const nextEntry = availableListEntries.shift();
+          return executeForSingleEntry(nextEntry);
+      }
+
+     return callback(undefined, result);
   };
 
   executeForSingleEntry(entry);


### PR DESCRIPTION
This PR fixes the "callback double calling issue" and should close **https://github.com/OpenDSU/opendsu/issues/18**.
This change makes the `promiseRunner` call the final callback after resolving or rejecting any pending operations thus preventing any errors thrown by the `callback` to be caught by the catch handler causing the `callback` to be called again with the error.

~~This fix is applied only to `promise.runOneSuccessful()`, if approved I will go ahead and update the rest of the methods that exhibit the bug.~~


