### PR TITLE
Fix unhandled rejection bug when domain is not configured

### DIFF
--- a/bdns/index.js
+++ b/bdns/index.js
@@ -34,7 +34,8 @@ function BDNS() {
                 return callback(Error(`The provided domain ${dlDomain} is not configured`));
             }
 
-            return bdnsCache[dlDomain][section] ? bdnsCache[dlDomain][section] : [getBaseURL()];
+            const config = bdnsCache[dlDomain][section] ? bdnsCache[dlDomain][section] : [getBaseURL()];
+            callback(undefined, config);
         }
 
         if (!isInitialized) {
@@ -42,13 +43,13 @@ function BDNS() {
                 if (dlDomain === undefined) {
                     return callback(new Error("The domain is not defined"));
                 }
-                callback(undefined, load_or_default());
+                return load_or_default();
             })
         }
         if (dlDomain === undefined) {
             return callback(new Error("The domain is not defined"));
         }
-        callback(undefined, load_or_default());
+        load_or_default();
     }
 
     this.getRawInfo = (dlDomain, callback) => {

--- a/tests/resolver/basic/CreateDSUWillFailOnPartialSupportedDomain.test.js
+++ b/tests/resolver/basic/CreateDSUWillFailOnPartialSupportedDomain.test.js
@@ -13,10 +13,11 @@ assert.callback('Create DSU on partial supported domain will fail', (testfinishe
 
     dc.createTestFolder('createDSU', (err, folder) => {
         testIntegration.launchApiHubTestNode(10, folder, (err) => {
-            const domain = 'testdomain';
+            const domain = 'default';
             prepareBDNSContext(folder);
-            createDSU(domain, (err, dus) => {
-                // assert.notEqual(typeof err, 'undefined');
+            createDSU(domain, (err, dsu) => {
+                assert.notEqual(typeof err, 'undefined', "DSU should not be created");
+                assert.true(err.message.indexOf(`The provided domain ${domain} is not configured`), "Error message should reflect unsupported domain");
 
                 testfinished();
             });

--- a/tests/resolver/basic/CreateDSUWillFailOnPartialSupportedDomain.test.js
+++ b/tests/resolver/basic/CreateDSUWillFailOnPartialSupportedDomain.test.js
@@ -17,7 +17,7 @@ assert.callback('Create DSU on partial supported domain will fail', (testfinishe
             prepareBDNSContext(folder);
             createDSU(domain, (err, dsu) => {
                 assert.notEqual(typeof err, 'undefined', "DSU should not be created");
-                assert.true(err.message.indexOf(`The provided domain ${domain} is not configured`), "Error message should reflect unsupported domain");
+                assert.true(err.message.indexOf(`The provided domain ${domain} is not configured`) !== -1, "Error message should reflect unsupported domain");
 
                 testfinished();
             });


### PR DESCRIPTION
This PR fixes a bug that triggers an unhandled rejection when a domain is not configured.
This fix should close: https://github.com/OpenDSU/opendsu/issues/17