### PR TITLE
Refresh cached DSU before load if new changes are detected

### DIFF
--- a/resolver/index.js
+++ b/resolver/index.js
@@ -139,20 +139,32 @@ const loadDSU = (keySSI, options, callback) => {
         }
     }
 
+    let cachingEnabled = true;
+    if (typeof options === 'object' && options !== null && options.skipCache) {
+        cachingEnabled = false;
+    }
 
-    const cacheKey = keySSI.getAnchorId()
-    const cachedDSU = dsuCache.get(cacheKey);
+    if (cachingEnabled) {
+        const cacheKey = keySSI.getAnchorId()
+        const cachedDSU = dsuCache.get(cacheKey);
 
-    if (cachedDSU) {
-        return latestDSUVersion(cachedDSU, keySSI, callback);
+        if (cachedDSU) {
+            return latestDSUVersion(cachedDSU, keySSI, callback);
+        }
     }
 
     const keySSIResolver = initializeResolver(options);
+
     keySSIResolver.loadDSU(keySSI, options, (err, dsuInstance) => {
         if (err) {
             return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to load DSU`, err));
         }
-        addDSUInstanceInCache(dsuInstance, callback);
+
+        if (cachingEnabled) {
+            return addDSUInstanceInCache(dsuInstance, callback);
+        }
+
+        callback(undefined, dsuInstance);
     });
 };
 

--- a/resolver/index.js
+++ b/resolver/index.js
@@ -101,7 +101,7 @@ const createDSUForExistingSSI = (ssi, options, callback) => {
  * current anchored HashLink with the latest anchored version.
  * If a new anchor is detected refresh the DSU
  */
-const latestDSUVersion = (dsu, keySSI, callback) => {
+const getLatestDSUVersion = (dsu, keySSI, callback) => {
     const current = dsu.getCurrentAnchoredHashLink();
     dsu.getLatestAnchoredHashLink((err, latest) => {
         if (err) {
@@ -109,13 +109,16 @@ const latestDSUVersion = (dsu, keySSI, callback) => {
         }
 
         if (current.getHash() === latest.getHash()) {
+            // No new version detected
             return callback(undefined, dsu);
         }
 
         if (dsu.hasUnanchoredChanges()) {
+            // The DSU is in the process of anchoring - don't refresh it
             return callback(undefined, dsu);
         }
 
+        // A new version is detected, refresh the DSU content
         dsu.refresh((err) => {
             if (err) {
                 return callback(err);
@@ -149,7 +152,7 @@ const loadDSU = (keySSI, options, callback) => {
         const cachedDSU = dsuCache.get(cacheKey);
 
         if (cachedDSU) {
-            return latestDSUVersion(cachedDSU, keySSI, callback);
+            return getLatestDSUVersion(cachedDSU, keySSI, callback);
         }
     }
 

--- a/resolver/index.js
+++ b/resolver/index.js
@@ -101,7 +101,7 @@ const createDSUForExistingSSI = (ssi, options, callback) => {
  * current anchored HashLink with the latest anchored version.
  * If a new anchor is detected refresh the DSU
  */
-const getLatestDSUVersion = (dsu, keySSI, callback) => {
+const getLatestDSUVersion = (dsu, callback) => {
     const current = dsu.getCurrentAnchoredHashLink();
     dsu.getLatestAnchoredHashLink((err, latest) => {
         if (err) {
@@ -152,7 +152,7 @@ const loadDSU = (keySSI, options, callback) => {
         const cachedDSU = dsuCache.get(cacheKey);
 
         if (cachedDSU) {
-            return getLatestDSUVersion(cachedDSU, keySSI, callback);
+            return getLatestDSUVersion(cachedDSU, callback);
         }
     }
 

--- a/tests/resolver/cache/double-check.json
+++ b/tests/resolver/cache/double-check.json
@@ -1,4 +1,4 @@
 {
   "confFileName": "double-check.json",
-  "ignore": ["dsuCacheTest.js", "dsuCacheTestChild.js"]
+  "ignore": ["dsuCacheTestChild.js"]
 }

--- a/tests/resolver/cache/skipCacheWhenLoadingDSUtest.js
+++ b/tests/resolver/cache/skipCacheWhenLoadingDSUtest.js
@@ -1,0 +1,134 @@
+const { promisify } = require('util');
+require("../../../../../psknode/bundles/testsRuntime");
+const testIntegration = require("../../../../../psknode/tests/util/tir");
+
+const dc = require("double-check");
+const assert = dc.assert;
+
+const resolver = require('../../../resolver');
+const keySSI = require("../../../keyssi")
+
+const _createDSU = promisify(resolver.createDSU);
+const _loadDSU = promisify(resolver.loadDSU);
+
+assert.callback('LoadDSUSkipCacheTest', (testfinished) => {
+
+    dc.createTestFolder('loadDSUSkipCache',(err,folder) => {
+        testIntegration.launchApiHubTestNode(10, folder, async (err) => {
+            if (err) {
+                throw err;
+            }
+
+            // Create parent, child DSUs
+            let [parentKeySSI, childKeySSI] = await createDSUs();
+
+            // Test that the same instance is returned when cached
+            let firstParentInstance = await loadDSU(parentKeySSI);
+            let secondParentInstance = await loadDSU(parentKeySSI);
+            assert.true(firstParentInstance === secondParentInstance, "Same DSU instance is returned when cached");
+
+            // Test that a different instance is returned when loading DSU with skipCache option
+            secondParentInstance = await loadDSU(parentKeySSI, { skipCache: true });
+            assert.true(firstParentInstance !== secondParentInstance, "Different DSU instance is returned when cache is skipped");
+
+            // Test the the "skipCache" option is propagated to dsu mounts
+            let childInstance = await loadDSU(childKeySSI);
+
+            // Update the child
+            await childInstance.writeFile('/info', 'updated');
+
+            const info = await secondParentInstance.readFile('/child/info');
+            assert.true(info.toString() === 'updated', "Child info isn't cached");
+
+            testfinished();
+        })
+    })
+}, 5000);
+
+async function createDSUs() {
+    // Create child DSU
+    const childDSU = await createDSU();
+    const childKeySSI = await childDSU.getKeySSIAsObject();
+    await childDSU.writeFile('/info', 'created');
+
+    // Create parent DSU
+    const parentDSU = await createDSU();
+    const parentKeySSI = await parentDSU.getKeySSIAsObject();
+
+    const sreadSSI = childKeySSI.derive().getIdentifier();
+    // Mount child in parent
+    await parentDSU.mount('/child', sreadSSI);
+    return [parentKeySSI, childKeySSI];
+}
+
+async function createDSU() {
+    const keyssi = await createKeySSI();
+    const dsu = await _createDSU(keyssi);
+
+    promisifyDSU(dsu);
+    return dsu;
+}
+
+async function loadDSU(...args) {
+    const dsu = await _loadDSU(...args)
+    promisifyDSU(dsu);
+    return dsu;
+}
+
+
+function createKeySSI(domain) {
+    domain = domain || 'default';
+    return new Promise((resolve, reject) => {
+        keySSI.createTemplateSeedSSI('default', (err, templateKeySSI) => {
+            if (err) {
+                return reject(err);
+            }
+            templateKeySSI.initialize(templateKeySSI.getDLDomain(), undefined, undefined, undefined, templateKeySSI.getHint(), (err, keySSI) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(keySSI);
+            });
+        });
+    })
+}
+
+
+function promisifyDSU(...args) {
+    // Methods to promisify
+    const methodsToPromisify = [
+        'getLastHashLinkSSI',
+        'getKeySSI',
+        'getKeySSIAsObject',
+        'getKeySSIAsString',
+        'addFiles',
+        'appendToFile',
+        'addFolder',
+        'addFile',
+        'readFile',
+        'extractFolder',
+        'extractFile',
+        'writeFile',
+        'delete',
+        'rename',
+        'listFiles',
+        'listFolders',
+        'createFolder',
+        'cloneFolder',
+        'enableAnchoringNotifications',
+        'enableAutoSync',
+        'readDir',
+        'mount',
+        'unmount',
+        'listMountedDSUs',
+        'commitBatch',
+        'cancelBatch',
+        'batch',
+    ]
+
+    for (const dsu of args) {
+        for (const method of methodsToPromisify) {
+            dsu[method] = promisify(dsu[method]);
+        }
+    }
+}

--- a/tests/resolver/cache/skipCacheWhenLoadingDSUtest.js
+++ b/tests/resolver/cache/skipCacheWhenLoadingDSUtest.js
@@ -76,8 +76,7 @@ async function loadDSU(...args) {
 }
 
 
-function createKeySSI(domain) {
-    domain = domain || 'default';
+function createKeySSI() {
     return new Promise((resolve, reject) => {
         keySSI.createTemplateSeedSSI('default', (err, templateKeySSI) => {
             if (err) {


### PR DESCRIPTION
Summary of changes:
* changed the behavior of `resolver.loadDSU()` to check the latest anchored hash link and if it is different then the cached version, refresh the DSU
* added the `skipCache` parameter to loadDSU so that DSUs loaded with this parameter enabled bypass the cache completely (the parameter is propagated to any mounted child DSUs). Usage example:

```resolver.loadDSU(keySSI, {skipCache: true}, callback)```