### PR TITLE
Fix performance issue when multiple versions have been anchored

### DIFF
--- a/anchoring/anchoring-utils.js
+++ b/anchoring/anchoring-utils.js
@@ -64,4 +64,5 @@ function verifySignature(keySSI, newSSI, lastSSI) {
 
 module.exports = {
     validateHashLinks,
+    verifySignature
 };

--- a/anchoring/cachedAnchoring.js
+++ b/anchoring/cachedAnchoring.js
@@ -37,7 +37,23 @@ function versions(anchorId, callback) {
     });
 }
 
+function latestVersion(anchorId, callback) {
+    const cache = cachedStores.getCacheForVault(storeName);
+    cache.get(anchorId, (err, hashLinkIds) => {
+        if (err) {
+            return OpenDSUSafeCallback(callback)(createOpenDSUErrorWrapper(`Failed to get anchor <${anchorId}> from cache`, err));
+        }
+
+        if (typeof hashLinkIds === "undefined") {
+            hashLinkIds = [];
+        }
+        const hashLinkSSIs = hashLinkIds.map(hashLinkId => keySSISpace.parse(hashLinkId));
+        return callback(undefined, hashLinkSSIs[hashLinkSSIs.length - 1]);
+    });
+}
+
 module.exports = {
     addVersion,
-    versions
+    versions,
+    latestVersion
 }


### PR DESCRIPTION
A possible fix for poor performance when loading a DSU having multiple anchored versions.

The cause for the performance drop is the HashLink validation step. Even though the default anchoring strategy loads only the latest BrickMap, before that happens, all the previous HashLinks are parsed and validated, causing a severe performance penalty.

The proposed fix only validates the signature of the latest HashLink - not sure of the security implications.

This PR is linked with: https://github.com/PrivateSky/bar/pull/7