### PR TITLE
Catch error when registering existing keyssi within enclave.

### DIFF
--- a/db/impl/BasicDB.js
+++ b/db/impl/BasicDB.js
@@ -36,6 +36,8 @@ function BasicDB(storageStrategy, conflictSolvingStrategy, options) {
     options = options || {events: false};
     ObservableMixin(this);
 
+    const errorAPI = require("opendsu").loadAPI("error");
+
     storageStrategy.on("initialised", () => {
         this.finishInitialisation();
         this.dispatchEvent("initialised");
@@ -89,7 +91,7 @@ function BasicDB(storageStrategy, conflictSolvingStrategy, options) {
         self.getRecord(tableName, key, function (err, res) {
             if (!err || res) {
                 //newRecord = Object.assign(newRecord, {__version:-1});
-                return callback(createOpenDSUErrorWrapper("Failed to insert over an existing record", new Error("Trying to insert into existing record")));
+                return callback(createOpenDSUErrorWrapper("Failed to insert over an existing record", new Error(errorAPI.DB_INSERT_EXISTING_RECORD_ERROR)));
             }
             const sharedDSUMetadata = {}
             sharedDSUMetadata.__version = 0;

--- a/error/index.js
+++ b/error/index.js
@@ -172,6 +172,8 @@ function printOpenDSUError(...args){
     }
 }
 
+const DB_INSERT_EXISTING_RECORD_ERROR = "Trying to insert into existing record";
+
 module.exports = {
     createOpenDSUErrorWrapper,
     reportUserRelevantError,
@@ -182,5 +184,6 @@ module.exports = {
     unobserveUserRelevantMessages,
     OpenDSUSafeCallback,
     registerMandatoryCallback,
-    printOpenDSUError
+    printOpenDSUError,
+    DB_INSERT_EXISTING_RECORD_ERROR
 }

--- a/http/node/fetch.js
+++ b/http/node/fetch.js
@@ -108,8 +108,9 @@ function Response(httpRequest, httpResponse) {
 		//data collecting
 		let rawData;
 		const contentType = httpResponse.headers['content-type'];
+        const isPartialContent = httpResponse.statusCode === 206;
 
-		if (contentType === "application/octet-stream") {
+		if (contentType === "application/octet-stream" || isPartialContent) {
 			rawData = [];
 		} else {
 			rawData = '';


### PR DESCRIPTION
**Changes**
- Catch error when registering existing keyssi within enclave.
- Fixed node fetch content type issue for stream response.

The first issue refers to the following situation (when we are in the context of a wallet):
```
const seedSSI = await $$.promisify(keySSISpace.createSeedSSI)(keySSI.getDLDomain());
const enclaveDB = await $$.promisify(dbSpace.getMainEnclaveDB)();
const dsu = await $$.promisify(enclaveDB.createDSU)(seedSSI);
```
When the first line is executed, both the **seedSSI** and **sReadSSI** derived from it are stored via enclave in their respective DBs
When the last line is executed, first enclave will try to store the **seedSSI**, operation which fails, because it was already saved when the **seedSSSI** was first created.
This PR handles the situation in which a keySSI is saved via enclave and it already exists in it's respective DB.

Another change handled in this PR, is the fetch package for node, in which the Response code 206 (Partial Content) should be handled as byte content (`rawData = [];`) and not as a string (`rawData = '';`)