### PR TITLE
refs #40 - exports mixins

### DIFF
--- a/enclave/index.js
+++ b/enclave/index.js
@@ -51,5 +51,7 @@ module.exports = {
     initialiseHighSecurityProxy,
     connectEnclave,
     createEnclave,
-    registerEnclave
+    registerEnclave,
+    EnclaveMixin: require("./impl/Enclave_Mixin"),
+    ProxyMixin: require("./impl/ProxyMixin")
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,3 +1,5 @@
 module.exports = {
-    bindAutoPendingFunctions: require("./BindAutoPendingFunctions").bindAutoPendingFunctions
+    bindAutoPendingFunctions: require("./BindAutoPendingFunctions").bindAutoPendingFunctions,
+    ObservableMixin: require("./ObservableMixin"),
+    PendingCallMixin: require('./PendingCallMixin')
 }

--- a/w3cdid/CryptographicSkills/CryptographicSkills.js
+++ b/w3cdid/CryptographicSkills/CryptographicSkills.js
@@ -23,5 +23,6 @@ registerSkills(methodsNames.KEY_SUBTYPE, new KeyDID_CryptographicSkills());
 module.exports = {
     registerSkills,
     applySkill,
-    NAMES: require("./cryptographicSkillsNames")
+    NAMES: require("./cryptographicSkillsNames"),
+    CryptographicSkillsMixin: require("./CryptographicSkillsMixin")
 };

--- a/w3cdid/index.js
+++ b/w3cdid/index.js
@@ -122,5 +122,7 @@ module.exports = {
     resolveDID,
     we_resolveDID,
     registerDIDMethod,
-    CryptographicSkills: require("./CryptographicSkills/CryptographicSkills")
+    CryptographicSkills: require("./CryptographicSkills/CryptographicSkills"),
+    W3CDIDMixin: require('./W3CDID_Mixin'),
+    W3CCVCMixin: require('./W3CVC_Mixin')
 }


### PR DESCRIPTION
Now exports Mixins for Observable, DID and Enclave. Also created a pull request in KeySSIResolve repo exporting KeySSI Mixin so that, in a later PR i can also export it from here (Otherwise new KeySSI types from outside OpenDSU are not possible/very code repeating), but for now, these 3 resolve our problem I think since we are only creating a new DID